### PR TITLE
Travis build deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,14 @@ script:
   - yarn test
   - yarn build
   # replace the pathways service in the config file with the gh static location
+  # and the cql-to-elm service with a public one
   # -i means in-place
   # see https://stackoverflow.com/a/11245501
-  # note also multiline string here to get around some yaml weirdness
+  # note multiline string here gets converted into one line, not 3
   - >
       sed -i "/pathwaysService:/c\  pathwaysService: 'https://mcode.github.io/pathways/static/pathways/'," build/config.js
+      &&
+      sed -i "/cqlToElmWebserviceUrl:/c\  cqlToElmWebserviceUrl: 'https://cql-translation-service-zfk47ib3kq-uc.a.run.app/cql/translator'," build/config.js
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ script:
   # replace the pathways service in the config file with the gh static location
   # -i means in-place
   # see https://stackoverflow.com/a/11245501
-  - sed -i "/pathwaysService:/c\  pathwaysService: 'https:\/\/mcode\.github\.io\/pathways\/static\/pathways\/'," build/config.js
+  # note also multiline string here to get around some yaml weirdness
+  - >
+      sed -i "/pathwaysService:/c\  pathwaysService: 'https://mcode.github.io/pathways/static/pathways/'," build/config.js
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ script:
   - yarn lint
   - yarn test
   - yarn build
+  # replace the pathways service in the config file with the gh static location
+  # -i means in-place
+  # see https://stackoverflow.com/a/11245501
+  - sed -i "/pathwaysService:/c\  pathwaysService: 'https:\/\/mcode\.github\.io\/pathways\/static\/pathways\/'," build/config.js
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,13 @@ cache: yarn
 script:
   - yarn lint
   - yarn test
+  - yarn build
+
+deploy:
+  provider: pages
+  local_dir: build
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+  keep_history: true
+  on:
+    branch: master

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "pathways",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://mcode.github.io/pathways",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.25",
     "@fortawesome/free-brands-svg-icons": "^5.11.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dagre": "^0.8.5",
     "eslint-plugin-only-error": "^1.0.2",
     "fhir-mapper": "^3.1.1",
-    "fhir-visualizers": "synthetichealth/fhir-visualizers",
+    "fhir-visualizers": "^0.0.1",
     "fhirclient": "^2.1.0",
     "node-sass": "^4.12.0",
     "react": "^16.10.1",

--- a/public/static/.pathways_readme
+++ b/public/static/.pathways_readme
@@ -1,0 +1,12 @@
+Note: the "index.html" file in the pathways folder
+is intentional. The idea is that it will ensure
+consistent behavior between GitHub Pages and 
+running the app locally with react-scripts.
+
+The file should contain a JSON representation of
+the list of filenames within the folder, 
+not including index.html itself.
+Yes it's a hack -- if we named it index.json, gh-pages will 
+serve it when we GET the folder,
+but react-scripts won't; instead it will serve up its
+own list of files in the directory, including index.json.

--- a/public/static/pathways/index.html
+++ b/public/static/pathways/index.html
@@ -1,0 +1,4 @@
+[
+  "breast_cancer_pathway.json",
+  "upenn_her2_pathway.json"
+]

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import 'react-app-polyfill/ie11';
 import 'react-app-polyfill/stable';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { HashRouter as Router, Route, Switch } from 'react-router-dom';
 import App from './components/App.tsx';
 import './styles/index.module.scss';
 import './utils/fontawesomeLibrary';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5221,9 +5221,10 @@ fhir-mapper@^3.1.1:
     fhirpath "^0.10.3"
     lodash "^4.17.13"
 
-fhir-visualizers@synthetichealth/fhir-visualizers:
+fhir-visualizers@^0.0.1:
   version "0.0.1"
-  resolved "https://codeload.github.com/synthetichealth/fhir-visualizers/tar.gz/8c7f448e42e71f9a8aa6fa8cb088f0cf3a4d1dd0"
+  resolved "https://registry.yarnpkg.com/fhir-visualizers/-/fhir-visualizers-0.0.1.tgz#037d05fda5bcaf308d84a7ba6e37302eaa014523"
+  integrity sha512-xGMkB6U2Ikh4eO6W0wi2eW8ONfTTmUBcVwYzT85VsCueQdXhtHMyhjly858hySRDChXYpZ8Gf3q4kAEBQ6kbMw==
   dependencies:
     moment "^2.24.0"
 


### PR DESCRIPTION
Adds a deploy step to the travis run script, based on instructions here: https://docs.travis-ci.com/user/deployment/pages/

Also adds the gh-pages URL to the package.json so that URLs in the build work as expected.

I tested this on a fork under my own account and it worked, see: https://github.com/dehall/pathways/tree/gh-pages and https://dehall.github.io/pathways/

The change to package.json and yarn.lock is to use the version of fhir-visualizers which is now on NPM, to fix this error: https://travis-ci.org/mcode/pathways/builds/646984479