### PR TITLE
Dynamic node height

### DIFF
--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -24,52 +24,63 @@ interface NodeIconProps {
   isGuidance: boolean;
 }
 
-const Node: FC<NodeProps> = ({
-  pathwayState,
-  documentation,
-  isOnPatientPath,
-  isCurrentNode,
-  xCoordinate,
-  yCoordinate,
-  expanded = false,
-  onClickHandler
-}) => {
-  const { label } = pathwayState;
-  const style = {
-    top: yCoordinate,
-    left: xCoordinate
-  };
-  const backgroundColorClass = isOnPatientPath ? classes.onPatientPath : classes.notOnPatientPath;
-  const currentNodeClass = isCurrentNode ? classes.current : '';
-  const expandedNodeClass = isCurrentNode
-    ? classes.childCurrent
-    : isOnPatientPath
-    ? classes.childOnPatientPath
-    : classes.childNotOnPatientPath;
-  const isGuidance = isGuidanceState(pathwayState);
-  return (
-    <div
-      className={`${classes.node} ${backgroundColorClass} ${expanded &&
-        nodeClasses.expanded} ${currentNodeClass}`}
-      style={style}
-    >
-      <div className={nodeClasses.nodeTitle} onClick={onClickHandler}>
-        <NodeIcon pathwayState={pathwayState} isGuidance={isGuidance} />
-        {label}
-      </div>
-      {expanded && (
-        <div className={`${classes.expandedNode} ${expandedNodeClass}`}>
-          <ExpandedNode
-            pathwayState={pathwayState as GuidanceState}
-            isActionable={isCurrentNode}
-            isGuidance={isGuidance}
-            documentation={documentation}
-          />
+export type NodeRef = HTMLDivElement;
+
+export const Node: FC<NodeProps & { ref: React.Ref<NodeRef> }> = React.forwardRef<
+  NodeRef,
+  NodeProps
+>(
+  (
+    {
+      pathwayState,
+      documentation,
+      isOnPatientPath,
+      isCurrentNode,
+      xCoordinate,
+      yCoordinate,
+      expanded = false,
+      onClickHandler
+    },
+    ref
+  ) => {
+    const { label } = pathwayState;
+    const style = {
+      top: yCoordinate,
+      left: xCoordinate
+    };
+    const backgroundColorClass = isOnPatientPath ? classes.onPatientPath : classes.notOnPatientPath;
+    const currentNodeClass = isCurrentNode ? classes.current : '';
+    const expandedNodeClass = isCurrentNode
+      ? classes.childCurrent
+      : isOnPatientPath
+      ? classes.childOnPatientPath
+      : classes.childNotOnPatientPath;
+    const isGuidance = isGuidanceState(pathwayState);
+    return (
+      <div
+        className={`${classes.node} ${backgroundColorClass} ${expanded &&
+          nodeClasses.expanded} ${currentNodeClass}`}
+        style={style}
+        ref={ref}
+      >
+        <div className={nodeClasses.nodeTitle} onClick={onClickHandler}>
+          <NodeIcon pathwayState={pathwayState} isGuidance={isGuidance} />
+          {label}
         </div>
-      )}
-    </div>
-  );
-};
+        {expanded && (
+          <div className={`${classes.expandedNode} ${expandedNodeClass}`}>
+            <ExpandedNode
+              pathwayState={pathwayState as GuidanceState}
+              isActionable={isCurrentNode}
+              isGuidance={isGuidance}
+              documentation={documentation}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+);
 
 const NodeIcon: FC<NodeIconProps> = ({ pathwayState, isGuidance }) => {
   let icon: IconProp = 'microscope';
@@ -85,5 +96,3 @@ const NodeIcon: FC<NodeIconProps> = ({ pathwayState, isGuidance }) => {
   }
   return <FontAwesomeIcon icon={icon} className={classes.icon} />;
 };
-
-export default Node;

--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, Ref, forwardRef } from 'react';
 import { GuidanceState, State, DocumentationResource } from 'pathways-model';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -24,12 +24,7 @@ interface NodeIconProps {
   isGuidance: boolean;
 }
 
-export type NodeRef = HTMLDivElement;
-
-export const Node: FC<NodeProps & { ref: React.Ref<NodeRef> }> = React.forwardRef<
-  NodeRef,
-  NodeProps
->(
+const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = forwardRef<HTMLDivElement, NodeProps>(
   (
     {
       pathwayState,
@@ -96,3 +91,5 @@ const NodeIcon: FC<NodeIconProps> = ({ pathwayState, isGuidance }) => {
   }
   return <FontAwesomeIcon icon={icon} className={classes.icon} />;
 };
+
+export default Node;

--- a/src/components/Node/index.ts
+++ b/src/components/Node/index.ts
@@ -1,1 +1,1 @@
-export * from './Node';
+export { default } from './Node';

--- a/src/components/Node/index.ts
+++ b/src/components/Node/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Node';
+export * from './Node';

--- a/src/engine/output-results.ts
+++ b/src/engine/output-results.ts
@@ -209,7 +209,7 @@ function nextState(
   const currentState = pathway.states[currentStateName];
   if ('action' in currentState) {
     let resource = patientData[currentStateName];
-    if (resource.length) {
+    if (resource?.length) {
       resource = resource[0]; // TODO: add functionality for multiple resources
       return {
         nextState: formatNextState(resource, currentState),

--- a/src/visualization/layout.ts
+++ b/src/visualization/layout.ts
@@ -36,13 +36,13 @@ function layoutDagre(pathway: Pathway, nodeDimensions: NodeDimensions): Layout {
 
   nodeNames.forEach(stateName => {
     const state: State = pathway.states[stateName];
-    const expanded = nodeDimensions[stateName];
+    const nodeDimension = nodeDimensions[stateName];
 
-    if (expanded) {
+    if (nodeDimension) {
       g.setNode(stateName, {
         label: state.label,
-        width: expanded.width,
-        height: expanded.height
+        width: nodeDimension.width,
+        height: nodeDimension.height
       });
     } else {
       g.setNode(stateName, {


### PR DESCRIPTION
- Node height is no longer manually calculated.
- Passed ref to each Node so that Graph can get height of each rendered node.
- Modified layout algorithm to take `nodeDimensions` parameter.
- Layout is recalculated when window size changes and when a node toggles expansion.

![image](https://user-images.githubusercontent.com/6588796/74365754-b0858a00-4d9c-11ea-8c40-7d699713c373.png)
