### PR TITLE
In-Progress Nodes

### DIFF
--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -23,7 +23,7 @@ const ExpandedNode: FC<ExpandedNodeProps> = ({
 }) => {
   const [comments, setComments] = useState<string>('');
 
-  const status = documentation?.resource && renderStatusFields(documentation);
+  const status = documentation?.resource && renderStatusField(documentation);
   const guidance = isGuidance && renderGuidance(pathwayState as GuidanceState, documentation);
   const branch = isBranchState(pathwayState) && renderBranch(documentation, pathwayState);
 
@@ -83,16 +83,12 @@ const ExpandedNodeField: FC<ExpandedNodeFieldProps> = ({ title, description }) =
   );
 };
 
-function renderStatusFields(documentation: DocumentationResource): ReactElement[] {
-  const returnValue: ReactElement[] = [];
-
+function renderStatusField(documentation: DocumentationResource): ReactElement {
   const status = documentation.status;
 
   const rawDate = documentation.resource?.meta?.lastUpdated;
   const date = rawDate && new Date(rawDate).toLocaleString('en-us');
-  returnValue.push(<ExpandedNodeField key="Status" title={status} description={date} />);
-
-  return returnValue;
+  return <ExpandedNodeField key="Status" title={status} description={date} />;
 }
 
 function renderBranch(

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -23,6 +23,7 @@ const ExpandedNode: FC<ExpandedNodeProps> = ({
 }) => {
   const [comments, setComments] = useState<string>('');
 
+  const status = documentation?.resource && renderStatusFields(documentation);
   const guidance = isGuidance && renderGuidance(pathwayState as GuidanceState, documentation);
   const branch = isBranchState(pathwayState) && renderBranch(documentation, pathwayState);
 
@@ -34,7 +35,10 @@ const ExpandedNode: FC<ExpandedNodeProps> = ({
   return (
     <div className={indexStyles.expandedNode}>
       <table className={styles.infoTable}>
-        <tbody>{guidance || branch}</tbody>
+        <tbody>
+          {status}
+          {guidance || branch}
+        </tbody>
       </table>
       {isActionable && (
         <form className={styles.commentsForm}>
@@ -78,6 +82,18 @@ const ExpandedNodeField: FC<ExpandedNodeFieldProps> = ({ title, description }) =
     </tr>
   );
 };
+
+function renderStatusFields(documentation: DocumentationResource): ReactElement[] {
+  const returnValue: ReactElement[] = [];
+
+  const status = documentation.status;
+
+  const rawDate = documentation.resource?.meta?.lastUpdated;
+  const date = rawDate && new Date(rawDate).toLocaleString('en-us');
+  returnValue.push(<ExpandedNodeField key="Status" title={status} description={date} />);
+
+  return returnValue;
+}
 
 function renderBranch(
   documentation: DocumentationResource | undefined,

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -23,7 +23,6 @@ const ExpandedNode: FC<ExpandedNodeProps> = ({
 }) => {
   const [comments, setComments] = useState<string>('');
 
-  const status = documentation?.resource && renderStatusField(documentation);
   const guidance = isGuidance && renderGuidance(pathwayState as GuidanceState, documentation);
   const branch = isBranchState(pathwayState) && renderBranch(documentation, pathwayState);
 
@@ -36,7 +35,7 @@ const ExpandedNode: FC<ExpandedNodeProps> = ({
     <div className={indexStyles.expandedNode}>
       <table className={styles.infoTable}>
         <tbody>
-          {status}
+          <StatusField documentation={documentation} />
           {guidance || branch}
         </tbody>
       </table>
@@ -83,13 +82,19 @@ const ExpandedNodeField: FC<ExpandedNodeFieldProps> = ({ title, description }) =
   );
 };
 
-function renderStatusField(documentation: DocumentationResource): ReactElement {
-  const status = documentation.status;
+type StatusFieldProps = {
+  documentation: DocumentationResource | undefined;
+};
 
+const StatusField: FC<StatusFieldProps> = ({ documentation }) => {
+  if (!documentation?.resource) {
+    return null;
+  }
+  const status = documentation.status;
   const rawDate = documentation.resource?.meta?.lastUpdated;
   const date = rawDate && new Date(rawDate).toLocaleString('en-us');
   return <ExpandedNodeField key="Status" title={status} description={date} />;
-}
+};
 
 function renderBranch(
   documentation: DocumentationResource | undefined,

--- a/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
+++ b/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
@@ -138,6 +138,11 @@ describe('<ExpandedNode />', () => {
       />
     );
 
+    expect(getByText(testDoc.status)).toBeVisible();
+    // date string from above. TODO: brittle
+    const date = new Date('2020-02-10T18:55:18.991+00:00').toLocaleString();
+    expect(getByText(date)).toBeVisible();
+
     // Form and buttons should be displayed in an active ExpandedNode
     expect(getByRole('form')).toBeVisible();
     expect(getByText('Accept')).toBeVisible();

--- a/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
+++ b/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
@@ -7,6 +7,8 @@ import {
   BasicMedicationRequestResource,
   DocumentationResource
 } from 'pathways-model';
+
+const fixedUpdatedDate = '2020-02-10T18:55:18.991+00:00';
 const testDoc: DocumentationResource = {
   resourceType: 'Observation',
   id: '138629',
@@ -17,7 +19,7 @@ const testDoc: DocumentationResource = {
     id: '138629',
     meta: {
       versionId: '1',
-      lastUpdated: '2020-02-10T18:55:18.991+00:00',
+      lastUpdated: fixedUpdatedDate,
       profile: [
         'http://hl7.org/fhir/us/shr/StructureDefinition/onco-core-TNMClinicalRegionalNodesCategory'
       ]
@@ -139,9 +141,9 @@ describe('<ExpandedNode />', () => {
     );
 
     expect(getByText(testDoc.status)).toBeVisible();
-    // date string from above. TODO: brittle
-    const date = new Date('2020-02-10T18:55:18.991+00:00').toLocaleString();
-    expect(getByText(date)).toBeVisible();
+    // TODO: brittle
+    const dateString = new Date(fixedUpdatedDate).toLocaleString();
+    expect(getByText(dateString)).toBeVisible();
 
     // Form and buttons should be displayed in an active ExpandedNode
     expect(getByRole('form')).toBeVisible();

--- a/src/components/Node/Node.module.scss
+++ b/src/components/Node/Node.module.scss
@@ -24,7 +24,7 @@
   background-color: $blue;
   color: $white;
 
-  &.current {
+  &.actionable {
     background-color: $red;
   }
 
@@ -51,7 +51,7 @@
     border: 1px solid $blue;
 
   }
-  &.childCurrent {
+  &.childActionable {
     border: 1px solid $red;
   }
 

--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -28,15 +28,6 @@ interface NodeProps {
   onClickHandler?: () => void;
 }
 
-interface NodeIconProps {
-  pathwayState: State;
-  isGuidance: boolean;
-}
-
-interface StatusIconProps {
-  accepted: boolean | null;
-}
-
 const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = forwardRef<HTMLDivElement, NodeProps>(
   (
     {
@@ -75,8 +66,8 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = forwardRef<HTMLDivEle
     // for now:
     // if it's a non-actionable guidance state on the path: accepted == has documentation
     // if it's actionable, not guidance or not on the path: null
-    const isAccepted =
-      isOnPatientPath && isGuidance && !isActionable ? documentation != null : null;
+    const wasActionTaken = isOnPatientPath && isGuidance && !isActionable;
+    const isAccepted = wasActionTaken ? documentation != null : null;
 
     return (
       <div className={topLevelClasses.join(' ')} style={style} ref={ref}>
@@ -102,6 +93,11 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = forwardRef<HTMLDivEle
   }
 );
 
+interface NodeIconProps {
+  pathwayState: State;
+  isGuidance: boolean;
+}
+
 const NodeIcon: FC<NodeIconProps> = ({ pathwayState, isGuidance }) => {
   let icon: IconProp = faMicroscope;
   if (pathwayState.label === 'Start') icon = faPlay;
@@ -116,6 +112,10 @@ const NodeIcon: FC<NodeIconProps> = ({ pathwayState, isGuidance }) => {
   }
   return <FontAwesomeIcon icon={icon} className={styles.icon} />;
 };
+
+interface StatusIconProps {
+  accepted: boolean | null;
+}
 
 const StatusIcon: FC<StatusIconProps> = ({ accepted }) => {
   if (accepted == null) {

--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -81,8 +81,10 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = forwardRef<HTMLDivEle
     return (
       <div className={topLevelClasses.join(' ')} style={style} ref={ref}>
         <div className={nodeStyles.nodeTitle} onClick={onClickHandler}>
-          <NodeIcon pathwayState={pathwayState} isGuidance={isGuidance} />
-          {label}
+          <div className={nodeStyles.iconAndLabel}>
+            <NodeIcon pathwayState={pathwayState} isGuidance={isGuidance} />
+            {label}
+          </div>
           <StatusIcon accepted={isAccepted} />
         </div>
         {expanded && (
@@ -120,7 +122,11 @@ const StatusIcon: FC<StatusIconProps> = ({ accepted }) => {
     return null;
   }
   const icon = accepted ? faCheckCircle : faTimesCircle;
-  return <FontAwesomeIcon icon={icon} className={styles.icon} />;
+  return (
+    <div className={nodeStyles.statusIcon}>
+      <FontAwesomeIcon icon={icon} className={styles.icon} />
+    </div>
+  );
 };
 
 export default Node;

--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -72,9 +72,11 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = forwardRef<HTMLDivEle
     }
     const isGuidance = isGuidanceState(pathwayState);
     // TODO: how do we determine whether a node has been accepted or declined?
-    // for now - if it's a guidance state on the path, accepted == has documentation
-    // if it's not guidance or not on the path, null
-    const isAccepted = isOnPatientPath && isGuidance ? documentation != null : null;
+    // for now:
+    // if it's a non-actionable guidance state on the path: accepted == has documentation
+    // if it's actionable, not guidance or not on the path: null
+    const isAccepted =
+      isOnPatientPath && isGuidance && !isActionable ? documentation != null : null;
 
     return (
       <div className={topLevelClasses.join(' ')} style={style} ref={ref}>

--- a/src/styles/_nodes.scss
+++ b/src/styles/_nodes.scss
@@ -14,10 +14,26 @@
     height: $collapsedNodeHeight;
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-end;
   }
 }
 
 .nodeTitle {
   padding: 15px;
+  /* use the entire width of its parent 
+     so we can align something to the right */
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.iconAndLabel {
+  flex-grow: 1;
+  text-align: center;
+}
+
+.statusIcon {
+  margin-left: auto;
+  padding-left: 10px;
 }

--- a/src/styles/_nodes.scss
+++ b/src/styles/_nodes.scss
@@ -19,7 +19,7 @@
 }
 
 .nodeTitle {
-  padding: 1em;
+  padding: 15px;
   /* use the entire width of its parent 
      so we can align something to the right */
   width: 100%;
@@ -35,5 +35,5 @@
 
 .statusIcon {
   margin-left: auto;
-  padding-left: 10px;
+  padding-left: .75em;
 }

--- a/src/styles/_nodes.scss
+++ b/src/styles/_nodes.scss
@@ -19,7 +19,7 @@
 }
 
 .nodeTitle {
-  padding: 15px;
+  padding: 1em;
   /* use the entire width of its parent 
      so we can align something to the right */
   width: 100%;


### PR DESCRIPTION
Adds a status field and icon to nodes indicating the status. Accepted nodes should be marked with a check, declined nodes should be marked with an X, and nodes that have already had an action taken on them should not be highlighted in red.

Note that we currently don't have the ability to accept/decline, so the logic for now is to assume anything actionable on the patient path with documentation was accepted, hence I don't think it's actually possible for anything to appear as declined yet.

### Samples

With the hardcoded demo patient:
![image](https://user-images.githubusercontent.com/13512036/75036544-1dc1ab00-5480-11ea-884d-63b058508276.png)
![image](https://user-images.githubusercontent.com/13512036/75036559-26b27c80-5480-11ea-81f4-24c65a90666a.png)

With "Magenta273 McOde090", who is based on Maureen but has a chemotherapy regimen started with status  "in progress"
![image](https://user-images.githubusercontent.com/13512036/75036648-56618480-5480-11ea-9999-6998bcebda1d.png)
![image](https://user-images.githubusercontent.com/13512036/75036739-9294e500-5480-11ea-9086-e656dbfd1407.png)
