### PR TITLE
On confirm popup

### DIFF
--- a/src/components/withConfirmationPopup/__tests__/withConfirmationPopup.test.tsx
+++ b/src/components/withConfirmationPopup/__tests__/withConfirmationPopup.test.tsx
@@ -11,7 +11,6 @@ const MockComponent: FC = () => {
 };
 
 const MockWithConfirmation: FC = withConfirmationPopup(MockComponent);
-const MockConfirmationWithCallback = withConfirmationPopup(MockComponent, mockCallback);
 
 describe('withConfirmationPopup', () => {
   it('renders the wrapped component', () => {
@@ -28,7 +27,7 @@ describe('withConfirmationPopup', () => {
   });
 
   it('calls the onConfirm callback when the confirmation is accepted', () => {
-    const { getByText, getByTestId } = render(<MockConfirmationWithCallback />);
+    const { getByText, getByTestId } = render(<MockWithConfirmation onConfirm={mockCallback} />);
     fireEvent.click(getByText(containerText));
     expect(mockCallback).not.toHaveBeenCalled();
     fireEvent.click(getByTestId('accept'));

--- a/src/components/withConfirmationPopup/withConfirmationPopup.tsx
+++ b/src/components/withConfirmationPopup/withConfirmationPopup.tsx
@@ -3,14 +3,16 @@ import styles from './withConfirmationPopup.module.scss';
 import PathwayPopup from 'components/PathwayPopup';
 import ActionButton from 'components/ActionButton';
 
-interface WithConfirmationPopupProps {
+type ConfirmationProps = {
   onConfirm?: () => void;
-}
+};
+
+type WithConfirmationPopupProps<T> = T & ConfirmationProps;
 
 const withConfirmationPopup = <T extends object>(
   WrappedComponent: FC<T>
-): FC<T & WithConfirmationPopupProps> => {
-  const PopupComponent: FC<T & WithConfirmationPopupProps> = ({ onConfirm, ...passed }) => {
+): FC<WithConfirmationPopupProps<T>> => {
+  const PopupComponent: FC<WithConfirmationPopupProps<T>> = ({ onConfirm, ...wrappedProps }) => {
     const [open, setOpen] = useState<boolean>(false);
     // https://github.com/Semantic-Org/Semantic-UI-React/issues/2487
     return (
@@ -20,8 +22,8 @@ const withConfirmationPopup = <T extends object>(
         open={open}
         setOpen={setOpen}
         Trigger={
-          <div className={styles.triggerContainer} {...passed}>
-            <WrappedComponent {...(passed as T)} />
+          <div className={styles.triggerContainer} {...wrappedProps}>
+            <WrappedComponent {...(wrappedProps as T)} />
           </div>
         }
       />

--- a/src/components/withConfirmationPopup/withConfirmationPopup.tsx
+++ b/src/components/withConfirmationPopup/withConfirmationPopup.tsx
@@ -3,11 +3,14 @@ import styles from './withConfirmationPopup.module.scss';
 import PathwayPopup from 'components/PathwayPopup';
 import ActionButton from 'components/ActionButton';
 
+interface WithConfirmationPopupProps {
+  onConfirm?: () => void;
+}
+
 const withConfirmationPopup = <T extends object>(
-  WrappedComponent: FC<T>,
-  onConfirm?: () => void
-): FC<T> => {
-  const PopupComponent: FC<T> = (props: T) => {
+  WrappedComponent: FC<T>
+): FC<T & WithConfirmationPopupProps> => {
+  const PopupComponent: FC<T & WithConfirmationPopupProps> = ({ onConfirm, ...passed }) => {
     const [open, setOpen] = useState<boolean>(false);
     // https://github.com/Semantic-Org/Semantic-UI-React/issues/2487
     return (
@@ -17,8 +20,8 @@ const withConfirmationPopup = <T extends object>(
         open={open}
         setOpen={setOpen}
         Trigger={
-          <div className={styles.triggerContainer} {...props}>
-            <WrappedComponent {...props} />
+          <div className={styles.triggerContainer} {...passed}>
+            <WrappedComponent {...(passed as T)} />
           </div>
         }
       />


### PR DESCRIPTION
`onConfirm` is now passed as a prop to `withConfirmationPopup` instead of as a function arg.

Created a small PR so that others can use this.