### PR TITLE
Remove tumor size from demo patient and only show buttons on Guidance states

### DIFF
--- a/public/static/pathways/breast_cancer_pathway.json
+++ b/public/static/pathways/breast_cancer_pathway.json
@@ -131,30 +131,6 @@
       ],
       "cql": "if [Procedure: \"Chemotherapy (procedure) code\"] then [Procedure: \"Chemotherapy (procedure) code\"] Chemo return Tuple{ resourceType: 'Procedure', id: Chemo.id.value, status: Chemo.status.value } else [MedicationRequest: \"10 ML Doxorubicin Hydrochloride 2 MG/ML Injection code\"] ChemoMedication where ToConcept(ChemoMedication.medication as FHIR.CodeableConcept) ~ \"10 ML Doxorubicin Hydrochloride 2 MG/ML Injection\"return Tuple{ resourceType: 'MedicationRequest', id: ChemoMedication.id.value, status: ChemoMedication.status.value } ",
       "transitions": []
-    },
-    "ChemoMedication": {
-      "label": "ChemoMedication Request",
-      "action": [
-        {
-          "type": "create",
-          "description": "Request 10ML Doxorubicin Hydrochloride 2MG/ML Injection",
-          "resource": {
-            "resourceType": "MedicationRequest",
-            "medicationCodeableConcept": {
-              "coding": [
-                {
-                  "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                  "code": "1790099",
-                  "display": "Doxorubicin"
-                }
-              ],
-              "text": "Doxorubicin"
-            }
-          }
-        }
-      ],
-      "cql": "[MedicationRequest: \"10 ML Doxorubicin Hydrochloride 2 MG/ML Injection code\"] ChemoMedication where ToConcept(ChemoMedication.medication as FHIR.CodeableConcept) ~ \"10 ML Doxorubicin Hydrochloride 2 MG/ML Injection\"return Tuple{ resourceType: 'MedicationRequest', id: ChemoMedication.id.value, status: ChemoMedication.status.value }",
-      "transitions": [{ "transition": "Chemo" }]
     }
   }
 }

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -39,7 +39,7 @@ const ExpandedNode: FC<ExpandedNodeProps> = ({
           {guidance || branch}
         </tbody>
       </table>
-      {isActionable && (
+      {isActionable && isGuidance && (
         <form className={styles.commentsForm}>
           <label>Comments:</label>
           <button

--- a/src/fixtures/MaureenMcodeDemoPatientRecords.json
+++ b/src/fixtures/MaureenMcodeDemoPatientRecords.json
@@ -7237,64 +7237,6 @@
   },
   {
     "resourceType": "Observation",
-    "id": "126124",
-    "meta": {
-      "versionId": "1",
-      "lastUpdated": "2019-08-22T17:03:11.110+00:00",
-      "profile": [
-        "http://hl7.org/fhir/us/shr/StructureDefinition/onco-core-TNMClinicalPrimaryTumorCategory"
-      ]
-    },
-    "extension": [
-      {
-        "url": "http://hl7.org/fhir/us/shr/DSTU2/StructureDefinition/onco-core-RelatedCancerCondition-extension",
-        "valueReference": {
-          "reference": "Condition/1d4d5de8-097d-4c5b-bb7b-48b5fd7fb441"
-        }
-      }
-    ],
-    "status": "final",
-    "category": {
-      "coding": [
-        {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "imaging",
-          "display": "imaging"
-        }
-      ],
-      "text": "imaging"
-    },
-    "code": {
-      "coding": [
-        {
-          "system": "http://loinc.org",
-          "code": "21905-5",
-          "display": "Primary tumor.clinical [Class] Cancer"
-        }
-      ],
-      "text": "Primary tumor.clinical [Class] Cancer"
-    },
-    "subject": {
-      "reference": "Patient/126040"
-    },
-    "encounter": {
-      "reference": "Encounter/126119"
-    },
-    "effectiveDateTime": "2018-10-18T22:02:14-04:00",
-    "issued": "2018-10-18T22:02:14.749-04:00",
-    "valueCodeableConcept": {
-      "coding": [
-        {
-          "system": "http://snomed.info/sct",
-          "code": "23351008",
-          "display": "T1"
-        }
-      ],
-      "text": "T1"
-    }
-  },
-  {
-    "resourceType": "Observation",
     "id": "126121",
     "meta": {
       "versionId": "1",


### PR DESCRIPTION
Two quick changes:

1 - Remove the tumor size Observation from the demo patient, in anticipation of a demo which will start with selecting a value for the Tumor Size branch

2 - Only show the Accept/Decline buttons and notes box on guidance states, not branches

![image](https://user-images.githubusercontent.com/13512036/75555576-81148580-5a0a-11ea-83e9-ffcc439efc3a.png)
