### PR TITLE
Add R4 FHIR types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "homepage": "https://mcode.github.io/pathways",
   "dependencies": {
+    "@ahryman40k/ts-fhir-types": "^4.0.25",
     "@fortawesome/fontawesome-svg-core": "^1.2.25",
     "@fortawesome/free-brands-svg-icons": "^5.11.2",
     "@fortawesome/free-solid-svg-icons": "^5.11.2",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -19,12 +19,13 @@ import FHIR from 'fhirclient';
 import demoRecords from 'fixtures/MaureenMcodeDemoPatientRecords.json';
 import { MockedFHIRClient } from 'utils/MockedFHIRClient';
 import { getHumanName } from 'utils/fhirUtils';
+import { Patient, DomainResource, Practitioner } from 'fhir-objects';
 interface AppProps {
   demo: boolean;
 }
 
 const App: FC<AppProps> = ({ demo }) => {
-  const [patientRecords, _setPatientRecords] = useState<fhir.DomainResource[]>([]);
+  const [patientRecords, _setPatientRecords] = useState<DomainResource[]>([]);
   const [currentPathway, setCurrentPathway] = useState<EvaluatedPathway | null>(null);
   const [selectPathway, setSelectPathway] = useState<boolean>(true);
   const [evaluatePath, setEvaluatePath] = useState<boolean>(false);
@@ -32,7 +33,7 @@ const App: FC<AppProps> = ({ demo }) => {
   const [client, setClient] = useState<PathwaysClient | null>(null);
   const [user, setUser] = useState<string>('');
 
-  const setPatientRecords = useCallback((value: fhir.DomainResource[]): void => {
+  const setPatientRecords = useCallback((value: DomainResource[]): void => {
     _setPatientRecords(value);
     setEvaluatePath(true);
   }, []);
@@ -46,7 +47,7 @@ const App: FC<AppProps> = ({ demo }) => {
         })
         .then(client => {
           // TODO: MockedFHIRClient has not mocked out requests for resources yet
-          getPatientRecord(client).then((records: fhir.DomainResource[]) => {
+          getPatientRecord(client).then((records: DomainResource[]) => {
             // filters out values that are empty
             // the server might return deleted
             // resources that only include an
@@ -68,7 +69,7 @@ const App: FC<AppProps> = ({ demo }) => {
 
   // gather note info
   useEffect(() => {
-    client?.user?.read().then((user: fhir.Practitioner) => {
+    client?.user?.read().then((user: Practitioner) => {
       const name = user.name && getHumanName(user.name);
       if (name) {
         setUser(name);
@@ -134,9 +135,7 @@ const App: FC<AppProps> = ({ demo }) => {
   return (
     <FHIRClientProvider client={client as PathwaysClient}>
       <PatientProvider
-        patient={
-          demo ? (demoRecords.find(r => r.resourceType === 'Patient') as fhir.Patient) : null
-        }
+        patient={demo ? (demoRecords.find(r => r.resourceType === 'Patient') as Patient) : null}
       >
         <PatientRecordsProvider
           value={{ patientRecords, setPatientRecords, evaluatePath, setEvaluatePath }}

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -16,6 +16,7 @@ import {
 } from 'utils/fhirUtils';
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { useNote } from 'components/NoteDataProvider';
+import { Resource, DocumentReference, Observation, Procedure, Identifier } from 'fhir-objects';
 interface ExpandedNodeProps {
   pathwayState: GuidanceState;
   isActionable: boolean;
@@ -52,7 +53,7 @@ const ExpandedNode: FC<ExpandedNodeProps> = ({
 
     // Translate pathway recommended resource and add to patient record
     if (action && action.length > 0) {
-      const resource: fhir.Resource = translatePathwayRecommendation(
+      const resource: Resource = translatePathwayRecommendation(
         action[0].resource,
         patient.id as string
       );
@@ -157,7 +158,7 @@ function renderBranch(
   if (documentation?.resource) {
     switch (documentation.resourceType) {
       case 'Observation': {
-        const observation = documentation.resource as fhir.Observation;
+        const observation = documentation.resource as Observation;
 
         const valueCoding = observation.valueCodeableConcept?.coding;
         if (valueCoding) {
@@ -196,7 +197,7 @@ function renderBranch(
         break;
       }
       case 'DocumentReference': {
-        const documentReference = documentation.resource as fhir.DocumentReference;
+        const documentReference = documentation.resource as DocumentReference;
         const subject = documentReference.subject;
         if (subject)
           returnElements.push(
@@ -204,7 +205,8 @@ function renderBranch(
           );
 
         // Display missing data value if it is available, otherwise display note content
-        const documentReferenceIdentifier = documentReference?.identifier?.find(
+        const identifierArray: Identifier[] | undefined = documentReference.identifier;
+        const documentReferenceIdentifier = identifierArray?.find(
           i => i.system === 'pathways.documentreference'
         );
 
@@ -281,7 +283,7 @@ function renderGuidance(
   if (documentation?.resource) {
     switch (documentation.resourceType) {
       case 'Procedure': {
-        const procedure = documentation.resource as fhir.Procedure;
+        const procedure = documentation.resource as Procedure;
         const start =
           (procedure.performedPeriod && procedure.performedPeriod.start) ||
           procedure.performedDateTime;

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -16,7 +16,15 @@ import {
 } from 'utils/fhirUtils';
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { useNote } from 'components/NoteDataProvider';
-import { Resource, DocumentReference, Observation, Procedure, Identifier } from 'fhir-objects';
+import {
+  Resource,
+  DocumentReference,
+  Observation,
+  Procedure,
+  Identifier,
+  MedicationRequest,
+  ServiceRequest
+} from 'fhir-objects';
 interface ExpandedNodeProps {
   pathwayState: GuidanceState;
   isActionable: boolean;
@@ -248,15 +256,20 @@ function renderBranch(
   return returnElements;
 }
 
+function isMedicationRequest(
+  request: MedicationRequest | ServiceRequest
+): request is MedicationRequest {
+  return (request as MedicationRequest).medicationCodeableConcept !== undefined;
+}
 function renderGuidance(
   pathwayState: GuidanceState,
   documentation: DocumentationResource | undefined
 ): ReactElement[] {
   const resource = pathwayState.action[0].resource;
-  const coding =
-    'medicationCodeableConcept' in resource
-      ? resource.medicationCodeableConcept.coding
-      : resource.code.coding;
+  const coding = isMedicationRequest(resource)
+    ? resource?.medicationCodeableConcept?.coding
+    : resource?.code?.coding;
+
   const returnElements = [
     <ExpandedNodeField
       key="Notes"
@@ -269,15 +282,15 @@ function renderGuidance(
       title="System"
       description={
         <>
-          {coding[0].system}
-          <a href={coding[0].system} target="_blank" rel="noopener noreferrer">
+          {coding && coding[0].system}
+          <a href={coding && coding[0].system} target="_blank" rel="noopener noreferrer">
             <FontAwesomeIcon icon={faExternalLinkAlt} className={styles.externalLink} />
           </a>
         </>
       }
     />,
-    <ExpandedNodeField key="Code" title="Code" description={coding[0].code} />,
-    <ExpandedNodeField key="Display" title="Display" description={coding[0].display} />
+    <ExpandedNodeField key="Code" title="Code" description={coding && coding[0].code} />,
+    <ExpandedNodeField key="Display" title="Display" description={coding && coding[0].display} />
   ];
 
   if (documentation?.resource) {

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -7,6 +7,7 @@ import { evaluatePatientOnPathway } from 'engine';
 import { EvaluatedPathway, PathwayResults, DocumentationResource } from 'pathways-model';
 import { Layout, NodeDimensions, Edge } from 'graph-model';
 import { usePatientRecords } from 'components/PatientRecordsProvider';
+import { DomainResource } from 'fhir-objects';
 
 interface GraphProps {
   evaluatedPathway: EvaluatedPathway;
@@ -104,7 +105,8 @@ const Graph: FC<GraphProps> = ({
       // Create a fake Bundle for the CQL engine and check if patientPath needs to be evaluated
       const patient = {
         resourceType: 'Bundle',
-        entry: resources.map((r: object) => ({ resource: r }))
+        type: 'searchset',
+        entry: resources.map((r: DomainResource) => ({ resource: r }))
       };
       evaluatePatientOnPathway(patient, pathway, resources).then(pathwayResults => {
         if (!cancel) setPath(pathwayResults);

--- a/src/components/PathwaysList/PathwaysList.tsx
+++ b/src/components/PathwaysList/PathwaysList.tsx
@@ -10,6 +10,7 @@ import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { usePathwayContext } from 'components/PathwayProvider';
 import { evaluatePathwayCriteria } from 'engine';
 import { usePatientRecords } from 'components/PatientRecordsProvider';
+import { Resource } from 'fhir-objects';
 import {
   faPlay,
   faPlus,

--- a/src/components/PathwaysList/PathwaysList.tsx
+++ b/src/components/PathwaysList/PathwaysList.tsx
@@ -40,6 +40,7 @@ const PathwaysList: FC<PathwaysListProps> = ({ evaluatedPathways, callback, serv
     // Create a fake Bundle for the CQL engine and check if patientPath needs to be evaluated
     const patient = {
       resourceType: 'Bundle',
+      type: 'searchset',
       entry: resources.map((r: fhir.Resource) => ({ resource: r }))
     };
 

--- a/src/components/PatientProvider.tsx
+++ b/src/components/PatientProvider.tsx
@@ -1,19 +1,19 @@
 import React, { FC, createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { useFHIRClient } from './FHIRClient';
-
+import { Patient } from 'fhir-objects';
 interface PatientProviderProps {
   children: ReactNode;
-  patient?: fhir.Patient | null;
+  patient?: Patient | null;
 }
 
-export const PatientContext = createContext<fhir.Patient | null>(null);
+export const PatientContext = createContext<Patient | null>(null);
 
 export const PatientProvider: FC<PatientProviderProps> = ({ children, patient }) => {
   const client = useFHIRClient();
-  const [currentPatient, setCurrentPatient] = useState<fhir.Patient | null>(patient || null);
+  const [currentPatient, setCurrentPatient] = useState<Patient | null>(patient || null);
 
   useEffect(() => {
-    client?.patient?.read?.().then((patient: fhir.Patient) => setCurrentPatient(patient));
+    client?.patient?.read?.().then((patient: Patient) => setCurrentPatient(patient));
   }, [client]);
 
   return currentPatient == null ? (
@@ -24,4 +24,4 @@ export const PatientProvider: FC<PatientProviderProps> = ({ children, patient })
 };
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-export const usePatient = (): fhir.Patient => useContext(PatientContext)!;
+export const usePatient = (): Patient => useContext(PatientContext)!;

--- a/src/components/PatientRecord/PatientRecord.tsx
+++ b/src/components/PatientRecord/PatientRecord.tsx
@@ -13,9 +13,9 @@ import {
   ProceduresVisualizer,
   ReportsVisualizer
 } from 'fhir-visualizers';
-
+import { DomainResource } from 'fhir-objects';
 const getResourceByType = (
-  patientRecord: ReadonlyArray<fhir.DomainResource>,
+  patientRecord: ReadonlyArray<DomainResource>,
   resourceType: string
 ): ReadonlyArray<object> => {
   return patientRecord.filter(resource => resource.resourceType === resourceType);

--- a/src/components/PatientRecordsProvider.tsx
+++ b/src/components/PatientRecordsProvider.tsx
@@ -1,12 +1,12 @@
 import React, { FC, createContext, useContext, ReactNode } from 'react';
-
+import { DomainResource } from 'fhir-objects';
 interface PatientRecordsProviderProps {
   children: ReactNode;
   value: PatientRecordsContextInterface;
 }
 
 interface PatientRecordsContextInterface {
-  patientRecords: fhir.DomainResource[];
+  patientRecords: DomainResource[];
   setPatientRecords: Function;
   evaluatePath: boolean;
   setEvaluatePath: (value: boolean) => void;

--- a/src/components/PatientSnapshot/PatientSnapshot.tsx
+++ b/src/components/PatientSnapshot/PatientSnapshot.tsx
@@ -4,8 +4,9 @@ import { usePatient } from '../PatientProvider';
 import { faUserCircle } from '@fortawesome/free-solid-svg-icons';
 
 import styles from './PatientSnapshot.module.scss';
+import { HumanName, Address } from 'fhir-objects';
 
-const getPatientName = (name: Array<fhir.HumanName> = []): string => {
+const getPatientName = (name: Array<HumanName> = []): string => {
   const entry = name.find(n => n.use === 'official') || name[0];
   return entry ? `${(entry.given || []).join(' ')} ${entry.family}` : 'No name';
 };
@@ -22,7 +23,7 @@ const getPatientAge = (birthDateString: string | undefined): number => {
   return age;
 };
 
-const getPatientAddress = (address: Array<fhir.Address> = []): string => {
+const getPatientAddress = (address: Array<Address> = []): string => {
   const entry = address[0];
   return entry ? [entry.city, entry.state].filter(item => !!item).join(', ') : 'No Address';
 };

--- a/src/engine/elm-executor.ts
+++ b/src/engine/elm-executor.ts
@@ -2,14 +2,18 @@
 import { ElmResults } from 'pathways-model';
 import { Library, Executor, Repository } from 'cql-execution';
 import { PatientSource } from 'cql-exec-fhir';
-
+import { Bundle } from 'fhir-objects';
 /**
  * Engine function that takes in a patient file (JSON) and an ELM file, running the patient against the ELM file
- * @param patient - FHIR bundle containing patient's record
+ * @param patientRecord - FHIR bundle containing patient's record
  * @param elm - ELM structure (previosuly converted from CQL) on which the patient will be run.
  * @return returns a JSON object which is the result of analyzing the patient against the elm file
  */
-export default function executeElm(patient: object, elm: object, libraries?: object): ElmResults {
+export default function executeElm(
+  patientRecord: Bundle,
+  elm: object,
+  libraries?: object
+): ElmResults {
   let lib;
   if (libraries) {
     lib = new Library(elm, new Repository(libraries));
@@ -18,8 +22,8 @@ export default function executeElm(patient: object, elm: object, libraries?: obj
   }
 
   const executor = new Executor(lib);
-  const psource = new PatientSource.FHIRv400(patient);
-  psource.loadBundles(patient);
+  const psource = new PatientSource.FHIRv400(patientRecord);
+  psource.loadBundles(patientRecord);
   const result = executor.exec(psource);
   return result;
 }

--- a/src/engine/evaluate-patient.ts
+++ b/src/engine/evaluate-patient.ts
@@ -38,7 +38,7 @@ export function evaluatePatientOnPathway(
 export function evaluatePathwayCriteria(
   patient: Bundle,
   pathway: Pathway
-): Promise<CriteriaResult[]> {
+): Promise<CriteriaResult> {
   return extractCriteriaCQL(pathway)
     .then(cql => processCQLCommon(patient, cql))
     .then(patientData => criteriaData(pathway, patientData));

--- a/src/engine/evaluate-patient.ts
+++ b/src/engine/evaluate-patient.ts
@@ -39,7 +39,6 @@ export function evaluatePathwayCriteria(
   patient: Bundle,
   pathway: Pathway
 ): Promise<CriteriaResult[]> {
-    console.log(patient);
   return extractCriteriaCQL(pathway)
     .then(cql => processCQLCommon(patient, cql))
     .then(patientData => criteriaData(pathway, patientData));

--- a/src/engine/evaluate-patient.ts
+++ b/src/engine/evaluate-patient.ts
@@ -5,7 +5,7 @@ import { pathwayData, criteriaData } from './output-results';
 import { Pathway, PatientData, PathwayResults, ElmResults, CriteriaResult } from 'pathways-model';
 import { getFixture } from './cql-extractor';
 import { extractCQLInclude } from 'utils/regexes';
-
+import { DomainResource, Bundle } from 'fhir-objects';
 function instanceOfElmObject(object: object): object is ElmObject {
   return 'main' in object;
 }
@@ -19,9 +19,9 @@ function instanceOfElmObject(object: object): object is ElmObject {
  *                  clinical pathway
  */
 export function evaluatePatientOnPathway(
-  patient: object,
+  patient: Bundle,
   pathway: Pathway,
-  resources: object[]
+  resources: DomainResource[]
 ): Promise<PathwayResults> {
   return extractNavigationCQL(pathway)
     .then(cql => processCQLCommon(patient, cql))
@@ -36,9 +36,10 @@ export function evaluatePatientOnPathway(
  *         the expected value and actual value for one criteria item
  */
 export function evaluatePathwayCriteria(
-  patient: object,
+  patient: Bundle,
   pathway: Pathway
-): Promise<CriteriaResult> {
+): Promise<CriteriaResult[]> {
+    console.log(patient);
   return extractCriteriaCQL(pathway)
     .then(cql => processCQLCommon(patient, cql))
     .then(patientData => criteriaData(pathway, patientData));
@@ -51,7 +52,7 @@ export function evaluatePathwayCriteria(
  * @return the raw, unprocessed patientResults
  *         derived from executing the CQL against the given patient
  */
-function processCQLCommon(patient: object, cql: string): Promise<PatientData> {
+function processCQLCommon(patient: Bundle, cql: string): Promise<PatientData> {
   // Likely need an intermediary step that gathers the CQL files needed
   // example function gatherCQL
   return gatherCQL(cql)

--- a/src/engine/output-results.ts
+++ b/src/engine/output-results.ts
@@ -11,7 +11,7 @@ import {
   GuidanceState,
   CriteriaResultItem
 } from 'pathways-model';
-
+import { DocumentReference, DomainResource } from 'fhir-objects';
 interface StateData {
   documentation: DocumentationResource | string | null;
   nextState: string | null;
@@ -169,7 +169,7 @@ function getConditionalNextState(
   patientData: PatientData,
   currentState: State,
   currentStateName: string,
-  resources: fhir.DomainResource[]
+  resources: DomainResource[]
 ): StateData {
   for (const transition of currentState.transitions) {
     if (transition.condition) {
@@ -228,7 +228,7 @@ function nextState(
   pathway: Pathway,
   patientData: PatientData,
   currentStateName: string,
-  resources: fhir.DomainResource[]
+  resources: DomainResource[]
 ): StateData | null {
   const currentState: State | GuidanceState = pathway.states[currentStateName];
   if ('action' in currentState) {
@@ -271,13 +271,10 @@ function nextState(
   } else return null;
 }
 
-function retrieveNote(
-  condition: string,
-  resources: fhir.DomainResource[]
-): fhir.DocumentReference | null {
+function retrieveNote(condition: string, resources: DomainResource[]): DocumentReference | null {
   const documentReference = resources.find(resource => {
     if (resource.resourceType !== 'DocumentReference') return false;
-    const documentReference = resource as fhir.DocumentReference;
+    const documentReference = resource as DocumentReference;
     if (documentReference.identifier === undefined) return false;
     for (const identifier of documentReference.identifier) {
       if (
@@ -291,12 +288,12 @@ function retrieveNote(
 
   if (!documentReference) return null;
 
-  return documentReference as fhir.DocumentReference;
+  return documentReference as DocumentReference;
 }
 
 function retrieveResource(
   doc: DocumentationResource | string,
-  resources: fhir.DomainResource[]
+  resources: DomainResource[]
 ): DocumentationResource | string {
   if (typeof doc !== 'string' && resources) {
     doc.resource = resources.find(resource => {

--- a/src/engine/output-results.ts
+++ b/src/engine/output-results.ts
@@ -34,7 +34,7 @@ interface StateData {
 export function pathwayData(
   pathway: Pathway,
   patientData: PatientData,
-  resources: object[]
+  resources: DomainResource[]
 ): PathwayResults {
   const startState = 'Start';
   let currentStatus;

--- a/src/testUtils/MockedPatientProvider.tsx
+++ b/src/testUtils/MockedPatientProvider.tsx
@@ -1,9 +1,9 @@
 import React, { FC, ReactNode } from 'react';
 import { PatientContext } from 'components/PatientProvider';
-
+import { Patient } from 'fhir-objects';
 interface PatientProviderProps {
   children: ReactNode;
-  patient?: fhir.Patient; // fhir.Patient | null;
+  patient?: Patient; // Patient | null;
 }
 
 export const mockedPatient = {

--- a/src/types/cql-exec.fhir.d.ts
+++ b/src/types/cql-exec.fhir.d.ts
@@ -2,8 +2,8 @@ declare module 'cql-exec-fhir' {
   import { Bundle } from 'fhir-objects';
   export const PatientSource = {
     FHIRv400: class {
-      constructor(patient: Bundle); // TODO: FHIR type
-      loadBundles(bundle: Bundle): void; // FHIR type here too
+      constructor(patient: Bundle);
+      loadBundles(bundle: Bundle): void;
     }
   };
 }

--- a/src/types/cql-exec.fhir.d.ts
+++ b/src/types/cql-exec.fhir.d.ts
@@ -1,8 +1,9 @@
 declare module 'cql-exec-fhir' {
+  import { Bundle } from 'fhir-objects';
   export const PatientSource = {
     FHIRv400: class {
-      constructor(patient: object); // TODO: FHIR type
-      loadBundles(bundle: object): void; // FHIR type here too
+      constructor(patient: Bundle); // TODO: FHIR type
+      loadBundles(bundle: Bundle): void; // FHIR type here too
     }
   };
 }

--- a/src/types/fhir-client.d.ts
+++ b/src/types/fhir-client.d.ts
@@ -1,4 +1,5 @@
 declare module 'pathways-client' {
+  import { Resource } from 'fhir-objects';
   export interface PathwaysClient {
     state?: Record<string, Record<string>>;
     environment?: Record<string, null, Record<string, boolean, Record<string>>>;
@@ -6,6 +7,6 @@ declare module 'pathways-client' {
     encounter?: Record<string, Function>;
     user?: Record<string, Function>;
     units?: Record<string, Function>;
-    create?: (resource: fhir.Resource) => Promise<fhir.Resource>;
+    create?: (resource: Resource) => Promise<Resource>;
   }
 }

--- a/src/types/fhir-objects.d.ts
+++ b/src/types/fhir-objects.d.ts
@@ -18,5 +18,4 @@ declare module 'fhir-objects' {
   export type Bundle = fhir.Bundle | R4.IBundle;
   export type ServiceRequest = fhir.ProcedureRequest | R4.IServiceRequest;
   export type MedicationRequest = fhir.MedicationRequest | R4.IMedicationRequest;
-  export type Request = ServiceRequest | MedicationRequest;
 }

--- a/src/types/fhir-objects.d.ts
+++ b/src/types/fhir-objects.d.ts
@@ -15,4 +15,8 @@ declare module 'fhir-objects' {
   export type Practitioner = fhir.Practitioner | R4.IPractitioner;
   export type Procedure = fhir.Procedure | R4.IProcedure;
   export type Resource = fhir.Resource | ResourceR4;
+  export type Bundle = fhir.Bundle | R4.IBundle;
+  export type ServiceRequest = fhir.ProcedureRequest | R4.IServiceRequest;
+  export type MedicationRequest = fhir.MedicationRequest | R4.IMedicationRequest;
+  export type Request = ServiceRequest | MedicationRequest;
 }

--- a/src/types/fhir-objects.d.ts
+++ b/src/types/fhir-objects.d.ts
@@ -1,0 +1,18 @@
+declare module 'fhir-objects' {
+  import { R4 } from '@ahryman40k/ts-fhir-types';
+
+  type DomainResourceR4 = R4.IDomainResource & { resourceType: string };
+  type ResourceR4 = R4.IResource & { resourceType: string };
+  type DocumentReferenceR4 = R4.IDocumentReference & { status: string };
+
+  export type Address = fhir.Address | R4.IAddress;
+  export type DomainResource = fhir.DomainResource | DomainResourceR4;
+  export type DocumentReference = fhir.DocumentReference | DocumentReferenceR4;
+  export type HumanName = fhir.HumanName | R4.IHumanName;
+  export type Identifier = fhir.Identifier | R4.IIdentifier;
+  export type Observation = fhir.Observation | R4.IObservation;
+  export type Patient = fhir.Patient | R4.IPatient;
+  export type Practitioner = fhir.Practitioner | R4.IPractitioner;
+  export type Procedure = fhir.Procedure | R4.IProcedure;
+  export type Resource = fhir.Resource | ResourceR4;
+}

--- a/src/types/fhir-visualizers.d.ts
+++ b/src/types/fhir-visualizers.d.ts
@@ -1,12 +1,13 @@
 declare module 'fhir-visualizers' {
   import React, { Component } from 'react';
+  import { Patient, DomainResource } from 'fhir-objects';
 
   type PatientVisualizerProps = {
-    patient: fhir.Patient;
+    patient: Patient;
   };
 
   type RowProps = {
-    rows: ReadonlyArray<fhir.DomainResource>;
+    rows: ReadonlyArray<DomainResource>;
   };
 
   export class PatientVisualizer extends Component<PatientVisualizerProps> {}

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -1,5 +1,5 @@
 declare module 'pathways-model' {
-  import { DomainResource } from 'fhir-objects';
+  import { DomainResource, Request } from 'fhir-objects';
   export interface Pathway {
     name: string;
     description?: string;
@@ -39,32 +39,8 @@ declare module 'pathways-model' {
   interface Action {
     type: string;
     description: string;
-    resource: BasicActionResource | BasicMedicationRequestResource; // TODO: FHIR resources
+    resource: Request;
   }
-
-  interface BasicResource {
-    resourceType: string;
-  }
-
-  interface BasicMedicationRequestResource extends BasicResource {
-    medicationCodeableConcept: Coding;
-  }
-
-  interface BasicActionResource extends BasicResource {
-    code: Coding;
-  }
-
-  interface Coding {
-    coding: Code[];
-    text?: string;
-  }
-
-  interface Code {
-    code: string;
-    system: string;
-    display: string;
-  }
-
   interface Transition {
     transition: string;
     condition?: {

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -1,5 +1,5 @@
 declare module 'pathways-model' {
-  import { DomainResource, Request } from 'fhir-objects';
+  import { DomainResource, MedicationRequest, ServiceRequest } from 'fhir-objects';
   export interface Pathway {
     name: string;
     description?: string;
@@ -39,7 +39,7 @@ declare module 'pathways-model' {
   interface Action {
     type: string;
     description: string;
-    resource: Request;
+    resource: MedicationRequest | ServiceRequest;
   }
   interface Transition {
     transition: string;

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -1,4 +1,5 @@
 declare module 'pathways-model' {
+  import { DomainResource } from 'fhir-objects';
   export interface Pathway {
     name: string;
     description?: string;
@@ -109,7 +110,7 @@ declare module 'pathways-model' {
         value: string;
       };
     };
-    [key: string]: Array<fhir.DomainResource, string> | fhir.DomainResource;
+    [key: string]: Array<DomainResource, string> | DomainResource;
   }
 
   export interface DocumentationResource {
@@ -117,7 +118,7 @@ declare module 'pathways-model' {
     id: string;
     status: string;
     state: string;
-    resource?: fhir.DomainResource;
+    resource?: DomainResource;
   }
 
   export interface PathwayContextInterface {

--- a/src/utils/MockedFHIRClient.ts
+++ b/src/utils/MockedFHIRClient.ts
@@ -1,7 +1,8 @@
+import { Resource } from 'fhir-objects';
 class MockedFHIRClient {
   patient = {};
 
-  async create(): Promise<fhir.Resource> {
+  async create(): Promise<Resource> {
     console.log('Mocked create');
     return Promise.resolve({});
   }

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -1,12 +1,20 @@
 import { BasicMedicationRequestResource, BasicActionResource, GuidanceState } from 'pathways-model';
 import { Note, toString } from 'components/NoteDataProvider';
+import {
+  Patient,
+  DomainResource,
+  Resource,
+  HumanName,
+  DocumentReference,
+  Observation
+} from 'fhir-objects';
 import { v1 } from 'uuid';
 
 // translates pathway recommendation resource into suitable FHIR resource
 export function translatePathwayRecommendation(
   pathwayResource: BasicMedicationRequestResource | BasicActionResource,
   patientId: string
-): fhir.Resource {
+): Resource {
   const { resourceType } = pathwayResource;
   const resourceProperties = {
     resourceType,
@@ -41,7 +49,7 @@ export function translatePathwayRecommendation(
   }
 }
 
-export function getHumanName(person: fhir.HumanName | fhir.HumanName[]): string {
+export function getHumanName(person: HumanName[]): string {
   let name = '';
   if (Array.isArray(person)) {
     name = [
@@ -50,13 +58,6 @@ export function getHumanName(person: fhir.HumanName | fhir.HumanName[]): string 
       person[0]?.family,
       person[0]?.suffix?.join(' ')
     ].join(' ');
-  } else {
-    name = [
-      person?.prefix?.join(' '),
-      person?.given?.join(' '),
-      person?.family,
-      person?.suffix?.join(' ')
-    ].join(' ');
   }
   return name;
 }
@@ -64,8 +65,8 @@ export function getHumanName(person: fhir.HumanName | fhir.HumanName[]): string 
 export function createDocumentReference(
   data: string,
   labelOrCondition: string,
-  patient: fhir.Patient
-): fhir.DocumentReference {
+  patient: Patient
+): DocumentReference {
   return {
     resourceType: 'DocumentReference',
     id: v1(),
@@ -104,7 +105,7 @@ export function createDocumentReference(
 
 export function createNoteContent(
   note: Note,
-  patientRecords: fhir.DomainResource[],
+  patientRecords: DomainResource[],
   status: string,
   notes: string,
   pathwayState?: GuidanceState
@@ -130,7 +131,7 @@ export function createNoteContent(
       const profile = record.meta.profile[0];
       if (record.resourceType === 'Observation') {
         if (profile.includes('TumorMarkerTest') && record.resourceType === 'Observation') {
-          const obs = record as fhir.Observation;
+          const obs = record as Observation;
           const value = obs.valueCodeableConcept?.text;
           const name = obs.code.text;
           if (value && name) {
@@ -145,7 +146,7 @@ export function createNoteContent(
             return profile.includes(value);
           });
           if (index > -1) {
-            const obs = record as fhir.Observation;
+            const obs = record as Observation;
             const value = obs.valueCodeableConcept?.text;
             if (value) {
               tnm[index] = value;

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -1,24 +1,35 @@
-import { BasicMedicationRequestResource, BasicActionResource, GuidanceState } from 'pathways-model';
+import { GuidanceState } from 'pathways-model';
 import { Note, toString } from 'components/NoteDataProvider';
 import {
   Patient,
   DomainResource,
-  Resource,
   HumanName,
   DocumentReference,
-  Observation
+  Observation,
+  ServiceRequest,
+  Request
 } from 'fhir-objects';
 import { v1 } from 'uuid';
+import { R4 } from '@ahryman40k/ts-fhir-types';
 
+interface MedProperties {
+  id: string;
+  resourceType: 'MedicationRequest';
+  intent: string;
+  subject: object;
+  status: string;
+  authoredOn: string;
+  meta: object;
+}
 // translates pathway recommendation resource into suitable FHIR resource
 export function translatePathwayRecommendation(
-  pathwayResource: BasicMedicationRequestResource | BasicActionResource,
+  pathwayResource: Request,
   patientId: string
-): Resource {
+): Request {
   const { resourceType } = pathwayResource;
   const resourceProperties = {
-    resourceType,
     id: v1(),
+    resourceType,
     intent: 'order',
     subject: { reference: `Patient/${patientId}` },
     status: 'active',
@@ -30,16 +41,17 @@ export function translatePathwayRecommendation(
 
   switch (resourceType) {
     case 'ServiceRequest': {
-      const { code } = pathwayResource as BasicActionResource;
+      const { code } = pathwayResource as ServiceRequest;
       return {
         ...resourceProperties,
         code
       };
     }
     case 'MedicationRequest': {
-      const { medicationCodeableConcept } = pathwayResource as BasicMedicationRequestResource;
+      const { medicationCodeableConcept } = pathwayResource as R4.IMedicationRequest;
+      const propertiesMed: MedProperties = resourceProperties as MedProperties;
       return {
-        ...resourceProperties,
+        ...propertiesMed,
         medicationCodeableConcept
       };
     }

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -7,16 +7,15 @@ import {
   DocumentReference,
   Observation,
   ServiceRequest,
-  MedicationRequest,
-  Request
+  MedicationRequest
 } from 'fhir-objects';
 import { v1 } from 'uuid';
 
 // translates pathway recommendation resource into suitable FHIR resource
 export function translatePathwayRecommendation(
-  pathwayResource: Request,
+  pathwayResource: MedicationRequest | ServiceRequest,
   patientId: string
-): Request {
+): MedicationRequest | ServiceRequest {
   const { resourceType } = pathwayResource;
   const resourceProperties = {
     id: v1(),
@@ -36,14 +35,14 @@ export function translatePathwayRecommendation(
       return {
         ...resourceProperties,
         code
-      } as Request;
+      } as ServiceRequest;
     }
     case 'MedicationRequest': {
       const { medicationCodeableConcept } = pathwayResource as MedicationRequest;
       return {
         ...resourceProperties,
         medicationCodeableConcept
-      } as Request;
+      } as MedicationRequest;
     }
     default: {
       throw Error(`Translation for ${resourceType} not implemented.`);

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -7,20 +7,11 @@ import {
   DocumentReference,
   Observation,
   ServiceRequest,
+  MedicationRequest,
   Request
 } from 'fhir-objects';
 import { v1 } from 'uuid';
-import { R4 } from '@ahryman40k/ts-fhir-types';
 
-interface MedProperties {
-  id: string;
-  resourceType: 'MedicationRequest';
-  intent: string;
-  subject: object;
-  status: string;
-  authoredOn: string;
-  meta: object;
-}
 // translates pathway recommendation resource into suitable FHIR resource
 export function translatePathwayRecommendation(
   pathwayResource: Request,
@@ -45,15 +36,14 @@ export function translatePathwayRecommendation(
       return {
         ...resourceProperties,
         code
-      };
+      } as Request;
     }
     case 'MedicationRequest': {
-      const { medicationCodeableConcept } = pathwayResource as R4.IMedicationRequest;
-      const propertiesMed: MedProperties = resourceProperties as MedProperties;
+      const { medicationCodeableConcept } = pathwayResource as MedicationRequest;
       return {
-        ...propertiesMed,
+        ...resourceProperties,
         medicationCodeableConcept
-      };
+      } as Request;
     }
     default: {
       throw Error(`Translation for ${resourceType} not implemented.`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@ahryman40k/ts-fhir-types@^4.0.25":
+  version "4.0.25"
+  resolved "https://registry.yarnpkg.com/@ahryman40k/ts-fhir-types/-/ts-fhir-types-4.0.25.tgz#d011296059074c49c17724c54cb4e9c09d225958"
+  integrity sha512-CceI1T/opTk728IXQ7oJlzOvQXUtBzqwyGnCpe3vyBErV6s73wMR9ZjKUPEfMTPpUxH9yuDEgZv4gBXGX1Uz9Q==
+  dependencies:
+    io-ts "<2.0.0"
+    reflect-metadata "^0.1.13"
+
 "@babel/code-frame@7.5.5", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -5497,6 +5505,11 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
+fp-ts@^1.0.0:
+  version "1.19.5"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.19.5.tgz#3da865e585dfa1fdfd51785417357ac50afc520a"
+  integrity sha512-wDNqTimnzs8QqpldiId9OavWK2NptormjXnRJTQecNjzwfyp6P/8s/zG8e4h3ja3oqkKaY72UlTjQYt/1yXf9A==
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -6339,6 +6352,13 @@ invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
+io-ts@<2.0.0:
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-1.10.4.tgz#cd5401b138de88e4f920adbcb7026e2d1967e6e2"
+  integrity sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==
+  dependencies:
+    fp-ts "^1.0.0"
 
 ip-regex@^2.1.0:
   version "2.1.0"
@@ -10053,6 +10073,11 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+reflect-metadata@^0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
 
 regenerate-unicode-properties@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
Basically creates a module `fhir-objects` that abstracts the STU3 and R4 types to a single type that is a union of the two.  Anywhere that used to use the fhir types has been replaced with one of these union types.  

In basically only one circumstance I found did the type difference actually matter, since STU3 and R4 are very similar anyway.  The union types can be used as standalone types for most purposes, aka you don't have to cast to a specific, versioned type and write two different functions if you don't need a property that is different between the two versions. 