### PR TITLE
Handle small window size

### DIFF
--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -80,6 +80,29 @@ const Graph: FC<GraphProps> = ({
       : 0;
   }, [nodeCoordinates]);
 
+  // If a node has a negative x value, shift nodes and edges to the right by that value
+  const minX =
+    nodeCoordinates !== undefined
+      ? Object.values(nodeCoordinates)
+          .map(x => x.x + windowWidth / 2)
+          .reduce((a, b) => Math.min(a, b))
+      : 0;
+
+  if (minX < 0) {
+    const toAdd = minX * -1;
+    Object.keys(nodeCoordinates).forEach(key => {
+      const node = nodeCoordinates[key];
+      node.x += toAdd;
+    });
+
+    Object.keys(edges).forEach(key => {
+      const edge = edges[key];
+
+      edge.points.forEach(p => (p.x += toAdd));
+      if (edge.label) edge.label.x += toAdd;
+    });
+  }
+
   const initialExpandedState = useMemo(() => {
     return Object.keys(layout).reduce((acc: { [key: string]: boolean }, curr: string) => {
       acc[curr] = false;

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -162,12 +162,12 @@ const Graph: FC<GraphProps> = ({
 
   // maxWidth finds the edge label that is farthest to the right
   const maxWidth: number =
-    edges !== undefined
+    (edges !== undefined
       ? Object.values(edges)
           .map(e => e.label)
           .map(l => (l ? l.x + l.text.length * 10 + windowWidth / 2 : 0))
           .reduce((a, b) => Math.max(a, b), 0)
-      : windowWidth;
+      : windowWidth) + 5;
 
   const documentation = evaluatedPathway.pathwayResults
     ? evaluatedPathway.pathwayResults.documentation
@@ -179,7 +179,8 @@ const Graph: FC<GraphProps> = ({
       style={{
         height: maxHeight + 150 + 'px',
         position: 'relative',
-        overflow: 'auto'
+        overflow: 'auto',
+        marginRight: '5px'
       }}
     >
       {nodeCoordinates !== undefined

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -162,12 +162,12 @@ const Graph: FC<GraphProps> = ({
 
   // maxWidth finds the edge label that is farthest to the right
   const maxWidth: number =
-    (edges !== undefined
+    edges !== undefined
       ? Object.values(edges)
           .map(e => e.label)
           .map(l => (l ? l.x + l.text.length * 10 + windowWidth / 2 : 0))
           .reduce((a, b) => Math.max(a, b), 0)
-      : windowWidth) + 5;
+      : windowWidth;
 
   const documentation = evaluatedPathway.pathwayResults
     ? evaluatedPathway.pathwayResults.documentation
@@ -213,7 +213,8 @@ const Graph: FC<GraphProps> = ({
       <svg
         xmlns="http://www.w3.org/2000/svg"
         style={{
-          width: maxWidth,
+          // Adding 5 pixels to maxWidth so that the rightmost edge label is not cut off
+          width: maxWidth + 5,
           height: maxHeight,
           zIndex: 1,
           top: 0,

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -177,7 +177,7 @@ const Graph: FC<GraphProps> = ({
     <div
       ref={graphElement}
       style={{
-        height: maxHeight + 150 + 'px',
+        height: interactive ? maxHeight + 150 : 'inherit',
         position: 'relative',
         overflow: 'auto',
         marginRight: '5px'

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -149,8 +149,16 @@ const Graph: FC<GraphProps> = ({
   const documentation = evaluatedPathway.pathwayResults
     ? evaluatedPathway.pathwayResults.documentation
     : [];
+
   return (
-    <div ref={graphElement} style={{ height: maxHeight + 150 + 'px', position: 'relative' }}>
+    <div
+      ref={graphElement}
+      style={{
+        height: maxHeight + 150 + 'px',
+        position: 'relative',
+        overflow: 'auto'
+      }}
+    >
       {nodeCoordinates !== undefined
         ? Object.keys(nodeCoordinates).map(key => {
             const docResource = documentation.find((doc): doc is DocumentationResource => {


### PR DESCRIPTION
- Adds scrollbar to div containing graph when content overflows
- Shifts nodes and edges to the right if content overflows to the left(could not figure out how to make scrollbar appear when content overflowed to the left)

![image](https://user-images.githubusercontent.com/6588796/77366193-e7e93e00-6d2d-11ea-981b-d1a46a72d6aa.png)
