### PR TITLE
Bump fhir-visualizers version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dagre": "^0.8.5",
     "eslint-plugin-only-error": "^1.0.2",
     "fhir-mapper": "^3.1.1",
-    "fhir-visualizers": "^0.0.1",
+    "fhir-visualizers": "~0.0.2",
     "fhirclient": "^2.1.0",
     "node-sass": "^4.12.0",
     "react": "^16.10.1",

--- a/src/engine/output-results.ts
+++ b/src/engine/output-results.ts
@@ -169,7 +169,7 @@ function getConditionalNextState(
   for (const transition of currentState.transitions) {
     if (transition.condition) {
       let currentTransitionDocumentation: DocumentationResource | null = null;
-      if (patientData[transition.condition.description].length)
+      if (patientData[transition.condition.description]?.length)
         // TODO: add functionality for multiple resources
         currentTransitionDocumentation = patientData[transition.condition.description][0];
       else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3290,6 +3290,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bootstrap@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.4.1.tgz#8582960eea0c5cd2bede84d8b0baf3789c3e8b01"
+  integrity sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -5402,11 +5407,12 @@ fhir-mapper@^3.1.1:
     fhirpath "^0.10.3"
     lodash "^4.17.13"
 
-fhir-visualizers@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/fhir-visualizers/-/fhir-visualizers-0.0.1.tgz#037d05fda5bcaf308d84a7ba6e37302eaa014523"
-  integrity sha512-xGMkB6U2Ikh4eO6W0wi2eW8ONfTTmUBcVwYzT85VsCueQdXhtHMyhjly858hySRDChXYpZ8Gf3q4kAEBQ6kbMw==
+fhir-visualizers@~0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/fhir-visualizers/-/fhir-visualizers-0.0.2.tgz#c4735d8b047aabcace26ee78cd706c3ca7f7673f"
+  integrity sha512-/GnrDyhcw3UJ/ulFajIr992jSjWMnZy9rQxMuraHumNrSh+Pd6fkm9k+VXejoOjjphR6C8g+Ekcs7heSSDHyIw==
   dependencies:
+    bootstrap "^4.4.1"
     moment "^2.24.0"
 
 fhirclient@^2.1.0:


### PR DESCRIPTION
- @dehall re-deployed an updated version of fhir-visualizers to npm and I bumped the version to 0.0.2 in `package.json`.

The error is actually no longer occurring on `master` since the neoadjuvant pathway now creates a proper `MedicationRequest`.  I added the old version onto the pathways server so that this can be tested.

- Launch the app via [SMART](http://moonshot-dev.mitre.org:4001/?auth_error=&fhir_version_1=r2&fhir_version_2=r4&iss=&launch_ehr=1&launch_url=http%3A%2F%2Flocalhost%3A3000%2F&patient=&prov_skip_auth=1&provider=&pt_skip_auth=1&public_key=&sb=&sde=&sim_ehr=0&token_lifetime=15&user_pt=)
- Choose a patient and choose the old neoadjuvant pathway
- Accept any chemotherapy regimen
- Open the patient viewer and view the list of medicationrequests

Should see something like this
![image](https://user-images.githubusercontent.com/6588796/78307343-ac135d00-7513-11ea-8416-76dd1a7f1188.png)
The app would previously crash when it couldn't get the code and display off of the medication resource. This version of fhir-visualizers catches the error and prevents the crash.