### PR TITLE
Expect MedicationRequests to be status "completed"

### DIFF
--- a/public/static/demoData/Maureen.json
+++ b/public/static/demoData/Maureen.json
@@ -7949,7 +7949,7 @@
       ]
     },
     "dateWritten": "2018-12-12T21:02:14-05:00",
-    "status": "stopped",
+    "status": "completed",
     "patient": {
       "reference": "Patient/126040"
     },
@@ -8320,7 +8320,7 @@
       ]
     },
     "dateWritten": "2018-12-12T21:02:14-05:00",
-    "status": "stopped",
+    "status": "completed",
     "patient": {
       "reference": "Patient/126040"
     },

--- a/src/engine/__tests__/fixtures/evaluationResults/sample_pathway/patient4.json
+++ b/src/engine/__tests__/fixtures/evaluationResults/sample_pathway/patient4.json
@@ -1,6 +1,6 @@
 {
   "patientId": "06da3260-0780-4e95-b3aa-33600e793a48",
-  "currentStates": ["Chemo"],
+  "currentStates": ["ChemoMedication"],
   "documentation": {
     "Start": {
       "state": "Start",

--- a/src/engine/__tests__/fixtures/patients/T0_patient.json
+++ b/src/engine/__tests__/fixtures/patients/T0_patient.json
@@ -21033,7 +21033,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "dcdbd869-49c4-43ba-a84e-4d42ab043183",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -22141,7 +22141,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "a4d14889-e6e7-4158-a47d-f5d2595294e7",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -22756,7 +22756,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "e5273db4-a0c2-430c-adce-5f0b2442cdf9",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -23371,7 +23371,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "4ebfcbee-bb9c-4e19-80f6-311a6ed91b80",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -23986,7 +23986,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "c9f0c339-bc4c-447f-bd3c-4e8251b51794",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -24601,7 +24601,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "2f63f2f6-07e7-4671-87c5-f9dd3ed937d4",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -25216,7 +25216,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "f50b571d-8468-4a6c-aa4f-0a454eec68b2",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -25882,7 +25882,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "a2b3d649-cde2-442a-8e32-5c1f452d9386",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -27231,7 +27231,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "1448e46d-ac3f-4141-a96d-95c7fbebd94e",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [

--- a/src/engine/__tests__/fixtures/patients/T1_patient.json
+++ b/src/engine/__tests__/fixtures/patients/T1_patient.json
@@ -50524,7 +50524,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "baf478d3-ce58-4559-b427-44a94dc5ae79",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [

--- a/src/engine/__tests__/fixtures/patients/triple_negative.json
+++ b/src/engine/__tests__/fixtures/patients/triple_negative.json
@@ -15724,7 +15724,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "61b75cbc-df21-4bd9-a28e-991b198575ee",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -16339,7 +16339,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "741c99f8-50a9-42ac-9694-b496dac53e7a",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -16954,7 +16954,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "33b3118c-1f2f-425b-b6df-dd54bd27a944",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -17569,7 +17569,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "2147c068-9cdf-4d4c-ab17-8deb49ac0664",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -18184,7 +18184,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "bbc2663b-e888-4cd0-91e9-7a68d19eaed1",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -18799,7 +18799,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "d19bf3e6-6572-4331-b6ac-49732c003c88",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -19414,7 +19414,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "52dbdcac-8296-4de0-9670-e5c05ea852e9",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -20080,7 +20080,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "67e8c4e7-781f-4587-a87f-d85d07d98c15",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -21359,7 +21359,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "39af832d-005d-4450-912a-6f6a244b7620",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -21957,7 +21957,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "ef8a97e3-8102-4831-8072-33d305254fb7",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -22555,7 +22555,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "b5aa7b2f-5a7e-4857-94dc-69aa843a8216",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -23153,7 +23153,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "f83f72ac-a932-45da-b187-b01ca86bf16a",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -23751,7 +23751,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "0ecc8d6a-98e0-4415-8407-ba4f76672fbc",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -24349,7 +24349,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "496c4eac-4e67-48a2-aa97-f8c80e28d5bf",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -24947,7 +24947,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "ec463b01-714b-4e57-b5cc-22463b2d353a",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [
@@ -25583,7 +25583,7 @@
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "2864a394-5339-485e-b759-b2dd5822c7c0",
-        "status": "stopped",
+        "status": "completed",
         "intent": "order",
         "medicationCodeableConcept": {
           "coding": [

--- a/src/engine/__tests__/output-results.test.ts
+++ b/src/engine/__tests__/output-results.test.ts
@@ -353,7 +353,7 @@ describe('pathway results translator', () => {
     };
     const patientPath = pathwayData(pathway, patientData, resources);
 
-    expect(patientPath.currentStates).toStrictEqual(['Chemo']);
+    expect(patientPath.currentStates).toStrictEqual(['ChemoMedication']);
     expect(patientPath.documentation).toEqual({
       Start: {
         state: 'Start',

--- a/src/engine/output-results.ts
+++ b/src/engine/output-results.ts
@@ -208,21 +208,29 @@ function formatDocumentation(
 }
 
 /**
+ * Helper function to determine whether the action represented by
+ * the given resource has been "completed", and the pathway execution should advance.
+ * @param resource - the FHIR resource for a given action
+ * @return boolean as to whether this resource is complete
+ */
+function isComplete(resource: DocumentationResource): boolean {
+  // placeholder for more complex logic if needed.
+  // as of today MedicationRequest and ServiceRequest should both be "completed"
+  // (MedicationRequest can also be "stopped" though that indicates
+  // "Actions implied by the prescription are to be permanently halted, **before all of them occurred.**")
+  return resource.status === 'completed';
+}
+
+/**
  * Helper function to select the transition state
- * This function is needed because MedicationRequests can have multiple
- * different statuses to indiciate complete
  * @param resource - the resource returned by the CQL execution
  * @param currentState - the current state
  * @return the next state name or null
  */
 function formatNextState(resource: DocumentationResource, currentState: State): string[] {
-  if (resource.resourceType === 'MedicationRequest') {
-    return currentState.transitions.length !== 0 ? [currentState.transitions[0].transition] : [];
-  } else {
-    return resource.status === 'completed' && currentState.transitions.length !== 0
-      ? [currentState.transitions[0].transition]
-      : [];
-  }
+  return isComplete(resource) && currentState.transitions.length !== 0
+    ? [currentState.transitions[0].transition]
+    : [];
 }
 
 /**


### PR DESCRIPTION
Currently there is a discrepancy in the app when accepting a recommendation -- if the recommendation is a ServiceRequest, it reloads and the same state is still active though no longer actionable, but if the recommendation is a MedicationRequest, it advances through to the next state, even though that MedicationRequest hasn't been completed yet.

As it turns out, we had logic in there that ignored the "status" field for MedicationRequest, because at one point it seemed like there were multiple possible statuses for a MedicationRequest to indicate completion: "completed" and "stopped". As it turns out, "stopped" really means "stopped before completion" so we don't want to interpret that the same as "completed". Synthea uses "stopped" in its MedicationRequest resources but really it should be "completed" since the intent is that the entire course of treatment was done. (Thanks to May Terry for pointing that out in a review of some sample records)

This change checks for "completed" status again, and adds a helper function to determine if a resource is completed, which we can easily expand if needed.
I also updated demo patient Maureen's 2 medications to be completed instead of stopped, although that shouldn't really make a difference. 
Finally 2 unit tests had to be updated because they were expecting the patient to advance to the next state even though the relevant MedicationRequest is "active".

One other thing to be aware of - PATHWAYS-221 isn't one we've talked about in detail but I think it's something we'll need eventually. That task will add some way of manually advancing to the next state (for example, if a medication status was "stopped" but the oncologist wants to move forward with the pathway instead of cancelling it)