### PR TITLE
Pathways assignment

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -195,7 +195,7 @@ const App: FC<AppProps> = ({ demoId }) => {
                     evaluatedPathways={evaluatedPathways}
                     callback={setEvaluatedPathwayCallback}
                     service={service}
-                  ></PathwaysList>
+                  />
                 ) : (
                   <PatientView evaluatedPathway={currentPathway} />
                 )}

--- a/src/components/PathwaysList/PathwaysList.module.scss
+++ b/src/components/PathwaysList/PathwaysList.module.scss
@@ -88,6 +88,7 @@ $lineHeight: 35px;
         font-size: 1em;
         padding: 10px 15px;
         margin-top: 25px;
+        margin-left: 5px;
       }
     }
 

--- a/src/components/PathwaysList/PathwaysList.module.scss
+++ b/src/components/PathwaysList/PathwaysList.module.scss
@@ -4,6 +4,116 @@
 $verticalPadding: 20px;
 $lineHeight: 35px;
 
+@mixin pathwayElement($numElementsColor, $numElementsBgColor, $hoverColor) {
+  display: block;
+  margin-bottom: 1vh;
+  font-size: 1.1em;
+
+  .title {
+    padding: $verticalPadding 0 $verticalPadding 20px;
+    height: 2*$verticalPadding + $lineHeight;
+    line-height: $lineHeight;
+    width: 100%;
+    font-weight:700;
+
+    div {
+      display: inline-block;
+    }
+
+    .numElements {
+      float: right;
+      width: 35px;
+      height: 35px;
+      line-height: 35px;
+      margin-right: 25px;
+      color: $numElementsColor;
+      background-color: $numElementsBgColor;
+      border-radius: 100%;
+      text-align: center;
+    }
+
+    .expand {
+      float: right;
+      margin-right: 25px;
+      font-size: 1.2em;
+    }
+
+    &:hover, &:focus {
+      cursor: pointer;
+    }
+  }
+
+  .infoContainer {
+    padding: 4px;
+    width: 100%;
+    height: 500px;
+
+    .details, .pathway {
+      display: block;
+      float: left;
+      height: 100%;
+      background-color: $white;
+    }
+
+    .details {
+      width: calc(65% - 5px);
+      padding: 15px;
+      margin-right: 10px;
+      font-size: 0.8em;
+
+      table {
+        border-collapse: collapse;
+        margin-top: 15px;
+      }
+
+      p {
+        font-style: italic;
+      }
+
+      td, th {
+        padding: 4px 50px 4px 0px;
+        min-width: 50px;
+      }
+
+      .matchingElement {
+        color: $blue;
+        font-weight: bold;
+      }
+
+      tr {
+        border-bottom: 2px solid $gray-lighter;
+      }
+
+      button {
+        font-size: 1em;
+        padding: 10px 15px;
+        margin-top: 25px;
+      }
+    }
+
+    .pathway {
+      position: relative;
+      width: calc(35% - 5px);
+      overflow: hidden;
+
+      .controls {
+        position: absolute;
+        top: 20px;
+        right: 10px;
+        width: 20px;
+
+        svg {
+          display: inline;
+        }
+      }
+    }
+  }
+
+  &:hover, &:focus{
+    background-color: darken($hoverColor, 10%);
+  }
+}
+
 .pathways_list {
   .header_title {
     display: flex;
@@ -29,114 +139,13 @@ $lineHeight: 35px;
     }
   }
 
+  .selectedPathwayElement {
+    @include pathwayElement($blue, $white, $blue);
+    background-color: $blue;
+  }
+
   .pathwayElement {
-    display: block;
-    margin-bottom: 1vh;
-    font-size: 1.1em;
-
-    .title {
-      padding: $verticalPadding 0 $verticalPadding 20px;
-      height: 2*$verticalPadding + $lineHeight;
-      line-height: $lineHeight;
-      width: 100%;
-      font-weight:700;
-
-      div {
-        display: inline-block;
-      }
-
-      .numElements {
-        float: right;
-        width: 35px;
-        height: 35px;
-        line-height: 35px;
-        margin-right: 25px;
-        color: $white;
-        background-color: $blue;
-        border-radius: 100%;
-        text-align: center;
-      }
-
-      .expand {
-        float: right;
-        margin-right: 25px;
-        font-size: 1.2em;
-      }
-
-      &:hover, &:focus {
-        cursor: pointer;
-      }
-    }
-
-    .infoContainer {
-      padding: 4px;
-      width: 100%;
-      height: 500px;
-
-      .details, .pathway {
-        display: block;
-        float: left;
-        height: 100%;
-        background-color: $white;
-      }
-
-      .details {
-        width: calc(65% - 5px);
-        padding: 15px;
-        margin-right: 10px;
-        font-size: 0.8em;
-
-        table {
-          border-collapse: collapse;
-          margin-top: 15px;
-        }
-
-        p {
-          font-style: italic;
-        }
-
-        td, th {
-          padding: 4px 50px 4px 0px;
-          min-width: 50px;
-        }
-
-        .matchingElement {
-          color: $blue;
-          font-weight: bold;
-        }
-
-        tr {
-          border-bottom: 2px solid $gray-lighter;
-        }
-
-        button {
-          font-size: 1em;
-          padding: 10px 15px;
-          margin-top: 25px;
-        }
-      }
-
-      .pathway {
-        position: relative;
-        width: calc(35% - 5px);
-        overflow: hidden;
-
-        .controls {
-          position: absolute;
-          top: 20px;
-          right: 10px;
-          width: 20px;
-
-          svg {
-            display: inline;
-          }
-        }
-      }
-    }
-
-    &:hover, &:focus{
-      background-color: darken($gray-lighter, 10%);
-    }
+    @include pathwayElement($white, $blue, $gray-lighter);
   }
 }
 

--- a/src/components/PathwaysList/PathwaysList.module.scss
+++ b/src/components/PathwaysList/PathwaysList.module.scss
@@ -18,6 +18,7 @@ $lineHeight: 35px;
 
     div {
       display: inline-block;
+      margin-right: 5px;
     }
 
     .numElements {

--- a/src/components/PathwaysList/PathwaysList.tsx
+++ b/src/components/PathwaysList/PathwaysList.tsx
@@ -230,6 +230,14 @@ const PathwaysListElement: FC<PathwaysListElementProps> = ({
             >
               Select Pathway
             </button>
+            <button
+              className={indexStyles.button}
+              onClick={(): void => {
+                callback(evaluatedPathway);
+              }}
+            >
+              View Pathway
+            </button>
           </div>
           <div className={styles.pathway}>
             <div style={{ height: '100%', overflow: 'scroll' }}>

--- a/src/components/PathwaysList/PathwaysList.tsx
+++ b/src/components/PathwaysList/PathwaysList.tsx
@@ -108,15 +108,15 @@ const PathwaysList: FC<PathwaysListProps> = ({ evaluatedPathways, callback, serv
   }
 
   const getSelectedPathway = (): string | undefined => {
-    // Get all active CarePlan resource titles
-    const carePlanTitles = (resources.filter(r => r.resourceType === 'CarePlan') as CarePlan[])
+    // Get all active CarePlan resource texts
+    const carePlanTexts = (resources.filter(r => r.resourceType === 'CarePlan') as CarePlan[])
       .filter(r => r.status === 'active')
-      .map(r => r.title);
+      .map(r => r.text?.div);
 
-    // Check to see if any of the pathway names are in carePlanTitles
+    // Check to see if any of the pathway names are in carePlanTexts
     const selectedPathway = evaluatedPathways
       .map(p => p.pathway.name)
-      .find(n => carePlanTitles.includes(n));
+      .find(n => carePlanTexts.some(text => text?.includes(n)));
 
     return selectedPathway;
   };

--- a/src/components/PathwaysList/PathwaysList.tsx
+++ b/src/components/PathwaysList/PathwaysList.tsx
@@ -20,7 +20,8 @@ import {
   faMinus,
   faChevronUp,
   faChevronDown,
-  faCaretDown
+  faCaretDown,
+  faCheckCircle
 } from '@fortawesome/free-solid-svg-icons';
 import { usePatient } from 'components/PatientProvider';
 import { useFHIRClient } from 'components/FHIRClient';
@@ -191,6 +192,11 @@ const PathwaysListElement: FC<PathwaysListElementProps> = ({
         }}
       >
         <div>{pathway.name}</div>
+        {selected && (
+          <div>
+            <FontAwesomeIcon icon={faCheckCircle} />
+          </div>
+        )}
         <div className={styles.expand}>
           <FontAwesomeIcon icon={chevron} />
         </div>

--- a/src/components/PathwaysList/PathwaysList.tsx
+++ b/src/components/PathwaysList/PathwaysList.tsx
@@ -106,15 +106,15 @@ const PathwaysList: FC<PathwaysListProps> = ({ evaluatedPathways, callback, serv
   }
 
   const getSelectedPathways = (): string[] => {
-    // Get all active CarePlan resource texts
-    const carePlanTexts = (resources.filter(r => r.resourceType === 'CarePlan') as CarePlan[])
+    // Get all active CarePlan resource titles
+    const carePlanTitles = (resources.filter(r => r.resourceType === 'CarePlan') as CarePlan[])
       .filter(r => r.status === 'active')
-      .map(r => r.text?.div);
+      .map(r => r.title);
 
-    // Check to see if any of the pathway names are in carePlanTexts
+    // Check to see if any of the pathway names are in carePlanTitles
     const selectedPathways = evaluatedPathways
       .map(p => p.pathway.name)
-      .filter(n => carePlanTexts.some(text => text?.includes(n)));
+      .filter(n => carePlanTitles.includes(n));
 
     return selectedPathways;
   };

--- a/src/components/PathwaysList/PathwaysList.tsx
+++ b/src/components/PathwaysList/PathwaysList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useState } from 'react';
+import React, { FC, ReactNode, useState, ButtonHTMLAttributes } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
 import { Service } from 'pathways-objects';
@@ -181,6 +181,16 @@ const PathwaysListElement: FC<PathwaysListElementProps> = ({
   const titleClass = selected
     ? clsx(styles.title, classes['selected-title'])
     : clsx(styles.title, classes.title);
+
+  // Optional attributes for "Select Pathway" button
+  const selectButtonOpts: ButtonHTMLAttributes<HTMLButtonElement> = {};
+  if (!disableSelect) {
+    selectButtonOpts.className = indexStyles.button;
+  } else {
+    // Add tooltip to button
+    selectButtonOpts.title = 'Only one pathway may be selected at a time';
+  }
+
   return (
     <div className={pathwayElementClass} role={'list'} key={pathway.name}>
       <div
@@ -224,7 +234,7 @@ const PathwaysListElement: FC<PathwaysListElementProps> = ({
               </tbody>
             </table>
             <button
-              className={indexStyles.button}
+              {...selectButtonOpts}
               disabled={disableSelect}
               onClick={(): void => {
                 const carePlan = createCarePlan(pathway.name, patient);

--- a/src/components/PathwaysList/PathwaysList.tsx
+++ b/src/components/PathwaysList/PathwaysList.tsx
@@ -30,8 +30,14 @@ const useStyles = makeStyles(
     'pathway-element': {
       backgroundColor: theme.palette.background.default
     },
+    'selected-pathway-element': {
+      backgroundColor: theme.palette.primary.main
+    },
     title: {
       color: theme.palette.text.primary
+    },
+    'selected-title': {
+      color: theme.palette.common.white
     }
   }),
   { name: 'PathwaysList' }
@@ -42,6 +48,7 @@ interface PathwaysListElementProps {
   criteria?: CriteriaResult;
   callback: Function;
   selected: boolean;
+  disableSelect: boolean;
 }
 
 interface PathwaysListProps {
@@ -85,6 +92,7 @@ const PathwaysList: FC<PathwaysListProps> = ({ evaluatedPathways, callback, serv
                   callback={callback}
                   criteria={c}
                   selected={pathwayName === selectedPathway}
+                  disableSelect={selectedPathway !== undefined}
                   key={pathwayName}
                 />
               );
@@ -149,7 +157,8 @@ const PathwaysListElement: FC<PathwaysListElementProps> = ({
   evaluatedPathway,
   criteria,
   callback,
-  selected
+  selected,
+  disableSelect
 }) => {
   const classes = useStyles();
   const pathway = evaluatedPathway.pathway;
@@ -165,14 +174,16 @@ const PathwaysListElement: FC<PathwaysListElementProps> = ({
     setIsVisible(!isVisible);
   }
 
+  const pathwayElementClass = selected
+    ? clsx(styles.selectedPathwayElement, classes['selected-pathway-element'])
+    : clsx(styles.pathwayElement, classes['pathway-element']);
+  const titleClass = selected
+    ? clsx(styles.title, classes['selected-title'])
+    : clsx(styles.title, classes.title);
   return (
-    <div
-      className={clsx(styles.pathwayElement, classes['pathway-element'])}
-      role={'list'}
-      key={pathway.name}
-    >
+    <div className={pathwayElementClass} role={'list'} key={pathway.name}>
       <div
-        className={clsx(styles.title, classes.title)}
+        className={titleClass}
         role={'listitem'}
         onClick={(e): void => {
           pathwayCtx.setEvaluatedPathway(evaluatedPathway, true);
@@ -208,6 +219,7 @@ const PathwaysListElement: FC<PathwaysListElementProps> = ({
             </table>
             <button
               className={indexStyles.button}
+              disabled={disableSelect}
               onClick={(): void => {
                 const carePlan = createCarePlan(pathway.name, patient);
 

--- a/src/components/PathwaysList/PathwaysList.tsx
+++ b/src/components/PathwaysList/PathwaysList.tsx
@@ -172,20 +172,24 @@ const PathwaysListElement: FC<PathwaysListElementProps> = ({
     setIsVisible(!isVisible);
   }
 
-  const pathwayElementClass = selected
-    ? clsx(styles.selectedPathwayElement, classes['selected-pathway-element'])
-    : clsx(styles.pathwayElement, classes['pathway-element']);
-  const titleClass = selected
-    ? clsx(styles.title, classes['selected-title'])
-    : clsx(styles.title, classes.title);
+  const pathwayElementClass = clsx(
+    selected && styles.selectedPathwayElement,
+    selected && classes['selected-pathway-element'],
+    !selected && styles.pathwayElement,
+    !selected && classes['pathway-element']
+  );
+
+  const titleClass = clsx(
+    styles.title,
+    selected && classes['selected-title'],
+    !selected && classes.title
+  );
 
   // Optional attributes for "Select Pathway" button
   const selectButtonOpts: ButtonHTMLAttributes<HTMLButtonElement> = {};
   if (selected) {
     // Add tooltip to button
     selectButtonOpts.title = 'Pathway is already selected';
-  } else {
-    selectButtonOpts.className = indexStyles.button;
   }
 
   return (
@@ -199,11 +203,7 @@ const PathwaysListElement: FC<PathwaysListElementProps> = ({
         }}
       >
         <div>{pathway.name}</div>
-        {selected && (
-          <div>
-            <FontAwesomeIcon icon={faCheckCircle} />
-          </div>
-        )}
+        {selected && <FontAwesomeIcon icon={faCheckCircle} />}
         <div className={styles.expand}>
           <FontAwesomeIcon icon={chevron} />
         </div>
@@ -232,6 +232,7 @@ const PathwaysListElement: FC<PathwaysListElementProps> = ({
             </table>
             <button
               {...selectButtonOpts}
+              className={indexStyles.button}
               disabled={selected}
               onClick={(): void => {
                 const carePlan = createCarePlan(pathway.name, patient);

--- a/src/components/PathwaysList/__tests__/PathwaysList.test.tsx
+++ b/src/components/PathwaysList/__tests__/PathwaysList.test.tsx
@@ -15,6 +15,7 @@ import { loadingService, loadedService, errorService } from 'testUtils/services'
 import { evaluatedCriteria, evaluatedPathwayResults } from 'testUtils/MockedValues';
 import { Pathway, EvaluatedPathway } from 'pathways-model';
 import MockedPatientRecordsProvider from 'testUtils/MockedPatientRecordsProvider';
+import MockedPatientProvider from 'testUtils/MockedPatientProvider';
 
 jest.mock('engine');
 
@@ -23,7 +24,11 @@ const renderComponent = async (
 ): Promise<RenderResult | undefined> => {
   let result: RenderResult | undefined;
   await act(async () => {
-    result = render(<MockedPatientRecordsProvider>{component}</MockedPatientRecordsProvider>);
+    result = render(
+      <MockedPatientProvider>
+        <MockedPatientRecordsProvider>{component}</MockedPatientRecordsProvider>
+      </MockedPatientProvider>
+    );
     await wait();
   });
   return result;

--- a/src/styles/_button.scss
+++ b/src/styles/_button.scss
@@ -14,4 +14,9 @@
     &:hover, &:focus {
         background-color: darken($blue, 10%);
     }
+
+    &:disabled {
+        background-color: lighten($blue, 20%);
+        cursor: default;
+    }
 }

--- a/src/types/fhir-objects.d.ts
+++ b/src/types/fhir-objects.d.ts
@@ -18,4 +18,5 @@ declare module 'fhir-objects' {
   export type Bundle = fhir.Bundle | R4.IBundle;
   export type ServiceRequest = fhir.ProcedureRequest | R4.IServiceRequest;
   export type MedicationRequest = fhir.MedicationRequest | R4.IMedicationRequest;
+  export type CarePlan = R4.ICarePlan;
 }

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -10,6 +10,7 @@ import {
   MedicationRequest,
   CarePlan
 } from 'fhir-objects';
+import { R4 } from '@ahryman40k/ts-fhir-types';
 import { v1 } from 'uuid';
 
 // translates pathway recommendation resource into suitable FHIR resource
@@ -189,10 +190,23 @@ function withLeadingZero(n: number): string {
 
 export function createCarePlan(title: string, patient: Patient): CarePlan {
   return {
-    title,
     resourceType: 'CarePlan',
+    text: {
+      status: R4.NarrativeStatusKind._generated,
+      div: `<div> Assignment of patient to pathway ${title} </div>`
+    },
     status: 'active',
     intent: 'plan',
+    category: [
+      {
+        coding: [
+          {
+            system: 'http://hl7.org/fhir/us/core/CodeSystem/careplan-category',
+            code: 'assess-plan'
+          }
+        ]
+      }
+    ],
     subject: { reference: `Patient/${patient.id}` }
   };
 }

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -190,6 +190,7 @@ function withLeadingZero(n: number): string {
 
 export function createCarePlan(title: string, patient: Patient): CarePlan {
   return {
+    title,
     resourceType: 'CarePlan',
     text: {
       status: R4.NarrativeStatusKind._generated,

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -7,7 +7,8 @@ import {
   DocumentReference,
   Observation,
   ServiceRequest,
-  MedicationRequest
+  MedicationRequest,
+  CarePlan
 } from 'fhir-objects';
 import { v1 } from 'uuid';
 
@@ -184,4 +185,14 @@ function getCurrentTime(): string {
 
 function withLeadingZero(n: number): string {
   return n < 10 ? '0' + n : n.toString();
+}
+
+export function createCarePlan(title: string, patient: Patient): CarePlan {
+  return {
+    title,
+    resourceType: 'CarePlan',
+    status: 'active',
+    intent: 'plan',
+    subject: { reference: `Patient/${patient.id}` }
+  };
 }


### PR DESCRIPTION
- Clicking the 'Select Pathway' button now adds an active `CarePlan` resource, which has the pathway name as it's `title` property, to the patient record.
    - After selecting a pathway, the button is disabled for the pathway until we implement the unselect pathway button.
    - Should work on demo and launcher endpoints.
- Added 'View Pathway' button
- How we're searching for the selected pathway
    - Looks for all active careplans that has a title that matches one of the pathways in the list

![image](https://user-images.githubusercontent.com/6588796/79132766-e634f800-7d78-11ea-81f8-cf80571a5115.png)
-
![image](https://user-images.githubusercontent.com/6588796/79132855-049af380-7d79-11ea-8fd2-ffff2fa14d25.png)
-
![image](https://user-images.githubusercontent.com/6588796/79602812-31bd0e00-80b9-11ea-97e1-9dce31809355.png)


