### PR TITLE
mCODE Data + Report Modal

### DIFF
--- a/public/static/cql/elm/mCODE.elm.json
+++ b/public/static/cql/elm/mCODE.elm.json
@@ -1,0 +1,1107 @@
+{
+    "library": {
+      "annotation": [
+        {
+          "startLine": 41,
+          "startChar": 48,
+          "endLine": 41,
+          "endChar": 48,
+          "message": "Syntax error at :",
+          "errorType": "syntax",
+          "errorSeverity": "error",
+          "type": "CqlToElmError"
+        },
+        {
+          "startLine": 70,
+          "startChar": 5,
+          "endLine": 70,
+          "endChar": 43,
+          "message": "Could not resolve membership operator for terminology target of the retrieve.",
+          "errorType": "semantic",
+          "errorSeverity": "warning",
+          "type": "CqlToElmError"
+        },
+        {
+          "startLine": 74,
+          "startChar": 5,
+          "endLine": 74,
+          "endChar": 52,
+          "message": "Could not resolve membership operator for terminology target of the retrieve.",
+          "errorType": "semantic",
+          "errorSeverity": "warning",
+          "type": "CqlToElmError"
+        },
+        {
+          "startLine": 77,
+          "startChar": 5,
+          "endLine": 77,
+          "endChar": 53,
+          "message": "Could not resolve membership operator for terminology target of the retrieve.",
+          "errorType": "semantic",
+          "errorSeverity": "warning",
+          "type": "CqlToElmError"
+        },
+        {
+          "startLine": 80,
+          "startChar": 5,
+          "endLine": 80,
+          "endChar": 57,
+          "message": "Could not resolve membership operator for terminology target of the retrieve.",
+          "errorType": "semantic",
+          "errorSeverity": "warning",
+          "type": "CqlToElmError"
+        },
+        {
+          "startLine": 83,
+          "startChar": 5,
+          "endLine": 83,
+          "endChar": 43,
+          "message": "Could not resolve membership operator for terminology target of the retrieve.",
+          "errorType": "semantic",
+          "errorSeverity": "warning",
+          "type": "CqlToElmError"
+        },
+        {
+          "startLine": 86,
+          "startChar": 5,
+          "endLine": 86,
+          "endChar": 47,
+          "message": "Could not resolve membership operator for terminology target of the retrieve.",
+          "errorType": "semantic",
+          "errorSeverity": "warning",
+          "type": "CqlToElmError"
+        },
+        {
+          "startLine": 89,
+          "startChar": 5,
+          "endLine": 89,
+          "endChar": 39,
+          "message": "Could not resolve membership operator for terminology target of the retrieve.",
+          "errorType": "semantic",
+          "errorSeverity": "warning",
+          "type": "CqlToElmError"
+        }
+      ],
+      "identifier": {
+        "id": "mCODE",
+        "version": "1"
+      },
+      "schemaIdentifier": {
+        "id": "urn:hl7-org:elm",
+        "version": "r1"
+      },
+      "usings": {
+        "def": [
+          {
+            "localIdentifier": "System",
+            "uri": "urn:hl7-org:elm-types:r1"
+          },
+          {
+            "localIdentifier": "FHIR",
+            "uri": "http://hl7.org/fhir",
+            "version": "4.0.0"
+          }
+        ]
+      },
+      "codeSystems": {
+        "def": [
+          {
+            "name": "SNOMEDCT",
+            "id": "http://snomed.info/sct",
+            "accessLevel": "Public"
+          },
+          {
+            "name": "LOINC",
+            "id": "http://loinc.org",
+            "accessLevel": "Public"
+          }
+        ]
+      },
+      "codes": {
+        "def": [
+          {
+            "name": "Primary cancer code",
+            "id": "64572001",
+            "display": "Disease (disorder)",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "SNOMEDCT"
+            }
+          },
+          {
+            "name": "TNM clinical primary tumor code",
+            "id": "21905-5",
+            "display": "Primary tumor.clinical [Class] Cancer",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "LOINC"
+            }
+          },
+          {
+            "name": "TNM clinical regional nodes code",
+            "id": "21906-3",
+            "display": "Regional lymph nodes.clinical [Class] Cancer",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "LOINC"
+            }
+          },
+          {
+            "name": "TNM clinical distant metastases code",
+            "id": "21907-1",
+            "display": "Distant metastases.clinical [Class] Cancer",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "LOINC"
+            }
+          },
+          {
+            "name": "Estrogen receptor code",
+            "id": "85337-4",
+            "display": "Estrogen receptor Ag [Presence] in Breast cancer specimen by Immune stain",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "LOINC"
+            }
+          },
+          {
+            "name": "Progesterone receptor code",
+            "id": "85339-0",
+            "display": "Progesterone receptor Ag [Presence] in Breast cancer specimen by Immune stain",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "LOINC"
+            }
+          },
+          {
+            "name": "HER2 receptor code",
+            "id": "85319-2",
+            "display": "HER2 [Presence] in Breast cancer specimen by Immune stain",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "LOINC"
+            }
+          },
+          {
+            "name": "11p partial monosomy syndrome code",
+            "id": "4135001",
+            "display": "11p partial monosomy syndrome",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "SNOMEDCT"
+            }
+          },
+          {
+            "name": "Orbital lymphoma code",
+            "id": "13048006",
+            "display": "Orbital lymphoma",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "SNOMEDCT"
+            }
+          },
+          {
+            "name": "Delta heavy chain disease code",
+            "id": "20224008",
+            "display": "Delta heavy chain disease",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "SNOMEDCT"
+            }
+          },
+          {
+            "name": "Malignant neoplasm of breast code",
+            "id": "254837009",
+            "display": "Malignant neoplasm of breast",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "SNOMEDCT"
+            }
+          },
+          {
+            "name": "Primary malignant neoplasm of colon code",
+            "id": "93761005",
+            "display": "Primary malignant neoplasm of colon",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "SNOMEDCT"
+            }
+          },
+          {
+            "name": "Secondary malignant neoplasm of colon code",
+            "id": "94260004",
+            "display": "Secondary malignant neoplasm of colon",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "SNOMEDCT"
+            }
+          },
+          {
+            "name": "Carcinoma in situ of prostate (disorder) code",
+            "id": "92691004",
+            "display": "Carcinoma in situ of prostate (disorder)",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "SNOMEDCT"
+            }
+          },
+          {
+            "name": "Small cell carcinoma of lung (disorder) code",
+            "id": "254632001",
+            "display": "Small cell carcinoma of lung (disorder)",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "SNOMEDCT"
+            }
+          },
+          {
+            "name": "Non-small cell lung cancer (disorder) code",
+            "id": "254637007",
+            "display": "Non-small cell lung cancer (disorder)",
+            "accessLevel": "Public",
+            "codeSystem": {
+              "name": "SNOMEDCT"
+            }
+          }
+        ]
+      },
+      "concepts": {
+        "def": [
+          {
+            "name": "Primary cancer",
+            "accessLevel": "Public",
+            "code": [
+              {
+                "name": "Primary cancer code"
+              }
+            ]
+          },
+          {
+            "name": "PrimaryCancersVS",
+            "accessLevel": "Public",
+            "code": [
+              {
+                "name": "11p partial monosomy syndrome code"
+              },
+              {
+                "name": "Orbital lymphoma code"
+              },
+              {
+                "name": "Delta heavy chain disease code"
+              },
+              {
+                "name": "Malignant neoplasm of breast code"
+              },
+              {
+                "name": "Primary malignant neoplasm of colon code"
+              },
+              {
+                "name": "Secondary malignant neoplasm of colon code"
+              },
+              {
+                "name": "Carcinoma in situ of prostate (disorder) code"
+              },
+              {
+                "name": "Small cell carcinoma of lung (disorder) code"
+              },
+              {
+                "name": "Non-small cell lung cancer (disorder) code"
+              }
+            ]
+          }
+        ]
+      },
+      "statements": {
+        "def": [
+          {
+            "name": "Patient",
+            "context": "Patient",
+            "expression": {
+              "type": "SingletonFrom",
+              "operand": {
+                "dataType": "{http://hl7.org/fhir}Patient",
+                "type": "Retrieve"
+              }
+            }
+          },
+          {
+            "name": "ToCode",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "type": "FunctionDef",
+            "expression": {
+              "type": "If",
+              "condition": {
+                "asType": "{urn:hl7-org:elm-types:r1}Boolean",
+                "type": "As",
+                "operand": {
+                  "type": "IsNull",
+                  "operand": {
+                    "name": "coding",
+                    "type": "OperandRef"
+                  }
+                }
+              },
+              "then": {
+                "asType": "{urn:hl7-org:elm-types:r1}Code",
+                "type": "As",
+                "operand": {
+                  "type": "Null"
+                }
+              },
+              "else": {
+                "classType": "{urn:hl7-org:elm-types:r1}Code",
+                "type": "Instance",
+                "element": [
+                  {
+                    "name": "code",
+                    "value": {
+                      "path": "value",
+                      "type": "Property",
+                      "source": {
+                        "path": "code",
+                        "type": "Property",
+                        "source": {
+                          "name": "coding",
+                          "type": "OperandRef"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "system",
+                    "value": {
+                      "path": "value",
+                      "type": "Property",
+                      "source": {
+                        "path": "system",
+                        "type": "Property",
+                        "source": {
+                          "name": "coding",
+                          "type": "OperandRef"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "version",
+                    "value": {
+                      "path": "value",
+                      "type": "Property",
+                      "source": {
+                        "path": "version",
+                        "type": "Property",
+                        "source": {
+                          "name": "coding",
+                          "type": "OperandRef"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "display",
+                    "value": {
+                      "path": "value",
+                      "type": "Property",
+                      "source": {
+                        "path": "display",
+                        "type": "Property",
+                        "source": {
+                          "name": "coding",
+                          "type": "OperandRef"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "operand": [
+              {
+                "name": "coding",
+                "operandTypeSpecifier": {
+                  "name": "{http://hl7.org/fhir}Coding",
+                  "type": "NamedTypeSpecifier"
+                }
+              }
+            ]
+          },
+          {
+            "name": "ToConcept",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "type": "FunctionDef",
+            "expression": {
+              "type": "If",
+              "condition": {
+                "asType": "{urn:hl7-org:elm-types:r1}Boolean",
+                "type": "As",
+                "operand": {
+                  "type": "IsNull",
+                  "operand": {
+                    "name": "concept",
+                    "type": "OperandRef"
+                  }
+                }
+              },
+              "then": {
+                "asType": "{urn:hl7-org:elm-types:r1}Concept",
+                "type": "As",
+                "operand": {
+                  "type": "Null"
+                }
+              },
+              "else": {
+                "classType": "{urn:hl7-org:elm-types:r1}Concept",
+                "type": "Instance",
+                "element": [
+                  {
+                    "name": "codes",
+                    "value": {
+                      "type": "Query",
+                      "source": [
+                        {
+                          "alias": "C",
+                          "expression": {
+                            "path": "coding",
+                            "type": "Property",
+                            "source": {
+                              "name": "concept",
+                              "type": "OperandRef"
+                            }
+                          }
+                        }
+                      ],
+                      "relationship": [],
+                      "return": {
+                        "expression": {
+                          "name": "ToCode",
+                          "type": "FunctionRef",
+                          "operand": [
+                            {
+                              "name": "C",
+                              "type": "AliasRef"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "display",
+                    "value": {
+                      "path": "value",
+                      "type": "Property",
+                      "source": {
+                        "path": "text",
+                        "type": "Property",
+                        "source": {
+                          "name": "concept",
+                          "type": "OperandRef"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "operand": [
+              {
+                "name": "concept",
+                "operandTypeSpecifier": {
+                  "name": "{http://hl7.org/fhir}CodeableConcept",
+                  "type": "NamedTypeSpecifier"
+                }
+              }
+            ]
+          },
+          {
+            "name": "Primary Cancer Condition",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "expression": {
+              "type": "Query",
+              "source": [
+                {
+                  "alias": "Cancer",
+                  "expression": {
+                    "dataType": "{http://hl7.org/fhir}Condition",
+                    "codeProperty": "code",
+                    "type": "Retrieve",
+                    "codes": {
+                      "type": "ToList",
+                      "operand": {
+                        "name": "PrimaryCancersVS",
+                        "type": "ConceptRef"
+                      }
+                    }
+                  }
+                }
+              ],
+              "relationship": [],
+              "where": {
+                "type": "Equivalent",
+                "operand": [
+                  {
+                    "name": "ToConcept",
+                    "type": "FunctionRef",
+                    "operand": [
+                      {
+                        "strict": false,
+                        "type": "As",
+                        "operand": {
+                          "type": "Indexer",
+                          "operand": [
+                            {
+                              "path": "category",
+                              "scope": "Cancer",
+                              "type": "Property"
+                            },
+                            {
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "type": "Literal"
+                            }
+                          ]
+                        },
+                        "asTypeSpecifier": {
+                          "name": "{http://hl7.org/fhir}CodeableConcept",
+                          "type": "NamedTypeSpecifier"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "Primary cancer",
+                    "type": "ConceptRef"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "TNM Clinical Primary Tumor",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "expression": {
+              "dataType": "{http://hl7.org/fhir}Observation",
+              "codeProperty": "code",
+              "type": "Retrieve",
+              "codes": {
+                "type": "ToList",
+                "operand": {
+                  "name": "TNM clinical primary tumor code",
+                  "type": "CodeRef"
+                }
+              }
+            }
+          },
+          {
+            "name": "TNM Clinical Regional Nodes",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "expression": {
+              "dataType": "{http://hl7.org/fhir}Observation",
+              "codeProperty": "code",
+              "type": "Retrieve",
+              "codes": {
+                "type": "ToList",
+                "operand": {
+                  "name": "TNM clinical regional nodes code",
+                  "type": "CodeRef"
+                }
+              }
+            }
+          },
+          {
+            "name": "TNM Clinical Distant Metastases",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "expression": {
+              "dataType": "{http://hl7.org/fhir}Observation",
+              "codeProperty": "code",
+              "type": "Retrieve",
+              "codes": {
+                "type": "ToList",
+                "operand": {
+                  "name": "TNM clinical distant metastases code",
+                  "type": "CodeRef"
+                }
+              }
+            }
+          },
+          {
+            "name": "Estrogen Receptor Tumor Marker Test",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "expression": {
+              "dataType": "{http://hl7.org/fhir}Observation",
+              "codeProperty": "code",
+              "type": "Retrieve",
+              "codes": {
+                "type": "ToList",
+                "operand": {
+                  "name": "Estrogen receptor code",
+                  "type": "CodeRef"
+                }
+              }
+            }
+          },
+          {
+            "name": "Progesterone Receptor Tumor Marker Test",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "expression": {
+              "dataType": "{http://hl7.org/fhir}Observation",
+              "codeProperty": "code",
+              "type": "Retrieve",
+              "codes": {
+                "type": "ToList",
+                "operand": {
+                  "name": "Progesterone receptor code",
+                  "type": "CodeRef"
+                }
+              }
+            }
+          },
+          {
+            "name": "HER2 Receptor Tumor Marker Test",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "expression": {
+              "dataType": "{http://hl7.org/fhir}Observation",
+              "codeProperty": "code",
+              "type": "Retrieve",
+              "codes": {
+                "type": "ToList",
+                "operand": {
+                  "name": "HER2 receptor code",
+                  "type": "CodeRef"
+                }
+              }
+            }
+          },
+          {
+            "name": "Primary Cancer Condition Value",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "expression": {
+              "type": "Query",
+              "source": [
+                {
+                  "alias": "Cancer",
+                  "expression": {
+                    "name": "Primary Cancer Condition",
+                    "type": "ExpressionRef"
+                  }
+                }
+              ],
+              "relationship": [],
+              "return": {
+                "expression": {
+                  "path": "value",
+                  "type": "Property",
+                  "source": {
+                    "path": "display",
+                    "type": "Property",
+                    "source": {
+                      "type": "Indexer",
+                      "operand": [
+                        {
+                          "path": "coding",
+                          "type": "Property",
+                          "source": {
+                            "type": "Indexer",
+                            "operand": [
+                              {
+                                "type": "ToList",
+                                "operand": {
+                                  "path": "code",
+                                  "scope": "Cancer",
+                                  "type": "Property"
+                                }
+                              },
+                              {
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "type": "Literal"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                          "value": "0",
+                          "type": "Literal"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name": "Primary Cancer Condition Body Location Value",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "expression": {
+              "type": "Query",
+              "source": [
+                {
+                  "alias": "Cancer",
+                  "expression": {
+                    "name": "Primary Cancer Condition",
+                    "type": "ExpressionRef"
+                  }
+                }
+              ],
+              "relationship": [],
+              "return": {
+                "expression": {
+                  "path": "value",
+                  "type": "Property",
+                  "source": {
+                    "path": "display",
+                    "type": "Property",
+                    "source": {
+                      "type": "Indexer",
+                      "operand": [
+                        {
+                          "type": "Flatten",
+                          "operand": {
+                            "type": "Query",
+                            "source": [
+                              {
+                                "alias": "$this",
+                                "expression": {
+                                  "path": "bodySite",
+                                  "scope": "Cancer",
+                                  "type": "Property"
+                                }
+                              }
+                            ],
+                            "where": {
+                              "type": "Not",
+                              "operand": {
+                                "type": "IsNull",
+                                "operand": {
+                                  "path": "coding",
+                                  "type": "Property",
+                                  "source": {
+                                    "name": "$this",
+                                    "type": "AliasRef"
+                                  }
+                                }
+                              }
+                            },
+                            "return": {
+                              "expression": {
+                                "path": "coding",
+                                "type": "Property",
+                                "source": {
+                                  "name": "$this",
+                                  "type": "AliasRef"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                          "value": "0",
+                          "type": "Literal"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name": "TNM Clinical Primary Tumor Category Data Value (T Category)",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "expression": {
+              "type": "Query",
+              "source": [
+                {
+                  "alias": "Disease",
+                  "expression": {
+                    "name": "TNM Clinical Primary Tumor",
+                    "type": "ExpressionRef"
+                  }
+                }
+              ],
+              "relationship": [],
+              "return": {
+                "expression": {
+                  "path": "value",
+                  "type": "Property",
+                  "source": {
+                    "path": "display",
+                    "type": "Property",
+                    "source": {
+                      "type": "Indexer",
+                      "operand": [
+                        {
+                          "path": "coding",
+                          "type": "Property",
+                          "source": {
+                            "path": "value",
+                            "scope": "Disease",
+                            "type": "Property"
+                          }
+                        },
+                        {
+                          "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                          "value": "0",
+                          "type": "Literal"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name": "TNM Clinical Regional Nodes Category Data Value (N Category)",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "expression": {
+              "type": "Query",
+              "source": [
+                {
+                  "alias": "Disease",
+                  "expression": {
+                    "name": "TNM Clinical Regional Nodes",
+                    "type": "ExpressionRef"
+                  }
+                }
+              ],
+              "relationship": [],
+              "return": {
+                "expression": {
+                  "path": "value",
+                  "type": "Property",
+                  "source": {
+                    "path": "display",
+                    "type": "Property",
+                    "source": {
+                      "type": "Indexer",
+                      "operand": [
+                        {
+                          "path": "coding",
+                          "type": "Property",
+                          "source": {
+                            "path": "value",
+                            "scope": "Disease",
+                            "type": "Property"
+                          }
+                        },
+                        {
+                          "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                          "value": "0",
+                          "type": "Literal"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name": "TNM Clinical Distant Metastases Category Data Value (M Category)",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "expression": {
+              "type": "Query",
+              "source": [
+                {
+                  "alias": "Disease",
+                  "expression": {
+                    "name": "TNM Clinical Distant Metastases",
+                    "type": "ExpressionRef"
+                  }
+                }
+              ],
+              "relationship": [],
+              "return": {
+                "expression": {
+                  "path": "value",
+                  "type": "Property",
+                  "source": {
+                    "path": "display",
+                    "type": "Property",
+                    "source": {
+                      "type": "Indexer",
+                      "operand": [
+                        {
+                          "path": "coding",
+                          "type": "Property",
+                          "source": {
+                            "path": "value",
+                            "scope": "Disease",
+                            "type": "Property"
+                          }
+                        },
+                        {
+                          "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                          "value": "0",
+                          "type": "Literal"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name": "Estrogen Receptor Value",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "expression": {
+              "type": "Query",
+              "source": [
+                {
+                  "alias": "Test",
+                  "expression": {
+                    "name": "Estrogen Receptor Tumor Marker Test",
+                    "type": "ExpressionRef"
+                  }
+                }
+              ],
+              "relationship": [],
+              "return": {
+                "expression": {
+                  "path": "value",
+                  "type": "Property",
+                  "source": {
+                    "path": "display",
+                    "type": "Property",
+                    "source": {
+                      "type": "Indexer",
+                      "operand": [
+                        {
+                          "path": "coding",
+                          "type": "Property",
+                          "source": {
+                            "path": "value",
+                            "scope": "Test",
+                            "type": "Property"
+                          }
+                        },
+                        {
+                          "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                          "value": "0",
+                          "type": "Literal"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name": "Progesterone Receptor Value",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "expression": {
+              "type": "Query",
+              "source": [
+                {
+                  "alias": "Test",
+                  "expression": {
+                    "name": "Progesterone Receptor Tumor Marker Test",
+                    "type": "ExpressionRef"
+                  }
+                }
+              ],
+              "relationship": [],
+              "return": {
+                "expression": {
+                  "path": "value",
+                  "type": "Property",
+                  "source": {
+                    "path": "display",
+                    "type": "Property",
+                    "source": {
+                      "type": "Indexer",
+                      "operand": [
+                        {
+                          "path": "coding",
+                          "type": "Property",
+                          "source": {
+                            "path": "value",
+                            "scope": "Test",
+                            "type": "Property"
+                          }
+                        },
+                        {
+                          "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                          "value": "0",
+                          "type": "Literal"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name": "HER2 Receptor Value",
+            "context": "Patient",
+            "accessLevel": "Public",
+            "expression": {
+              "type": "Query",
+              "source": [
+                {
+                  "alias": "Test",
+                  "expression": {
+                    "name": "HER2 Receptor Tumor Marker Test",
+                    "type": "ExpressionRef"
+                  }
+                }
+              ],
+              "relationship": [],
+              "return": {
+                "expression": {
+                  "path": "value",
+                  "type": "Property",
+                  "source": {
+                    "path": "display",
+                    "type": "Property",
+                    "source": {
+                      "type": "Indexer",
+                      "operand": [
+                        {
+                          "path": "coding",
+                          "type": "Property",
+                          "source": {
+                            "path": "value",
+                            "scope": "Test",
+                            "type": "Property"
+                          }
+                        },
+                        {
+                          "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                          "value": "0",
+                          "type": "Literal"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/public/static/cql/mCODE.cql
+++ b/public/static/cql/mCODE.cql
@@ -12,35 +12,34 @@ code "Primary cancer code": '64572001' from "SNOMEDCT" display 'Disease (disorde
 code "TNM clinical primary tumor code": '21905-5' from "LOINC" display 'Primary tumor.clinical [Class] Cancer'
 code "TNM clinical regional nodes code": '21906-3' from "LOINC" display 'Regional lymph nodes.clinical [Class] Cancer'
 code "TNM clinical distant metastases code": '21907-1' from "LOINC" display 'Distant metastases.clinical [Class] Cancer'
-code "Tumor marker test code": 'laboratory' from "OBSCAT"
 code "Estrogen receptor code": '85337-4' from "LOINC" display 'Estrogen receptor Ag [Presence] in Breast cancer specimen by Immune stain'
 code "Progesterone receptor code": '85339-0' from "LOINC" display 'Progesterone receptor Ag [Presence] in Breast cancer specimen by Immune stain'
 code "HER2 receptor code": '85319-2' from "LOINC" display 'HER2 [Presence] in Breast cancer specimen by Immune stain'
 
 // selected cancer codes used within Synthea
 // not the entire list supported by PrimaryCancerConditionVS
-code "11p partial monosomy syndrome 4135001 code": '4135001' from SNOMEDCT display '11p partial monosomy syndrome'
-code "Orbital lymphoma 13048006 code": '13048006' from SNOMEDCT display 'Orbital lymphoma'
-code "Delta heavy chain disease 20224008 code": '20224008' from SNOMEDCT display 'Delta heavy chain disease'
-code "Malignant neoplasm of breast 254837009 code": '254837009' from SNOMEDCT display 'Malignant neoplasm of breast'
-code "Primary malignant neoplasm of colon 93761005 code": '93761005' from SNOMEDCT display 'Primary malignant neoplasm of colon'
-code "Secondary malignant neoplasm of colon 94260004 code": '94260004' from SNOMEDCT display 'Secondary malignant neoplasm of colon'
-code "Carcinoma in situ of prostate (disorder) 92691004 code": '92691004' from SNOMEDCT display 'Carcinoma in situ of prostate (disorder)'
-code "Small cell carcinoma of lung (disorder) 254632001 code": '254632001' from SNOMEDCT display 'Small cell carcinoma of lung (disorder)'
-code "Non-small cell lung cancer (disorder) 254637007 code": '254637007' from SNOMEDCT display 'Non-small cell lung cancer (disorder)'
+code "11p partial monosomy syndrome code": '4135001' from SNOMEDCT display '11p partial monosomy syndrome'
+code "Orbital lymphoma code": '13048006' from SNOMEDCT display 'Orbital lymphoma'
+code "Delta heavy chain disease code": '20224008' from SNOMEDCT display 'Delta heavy chain disease'
+code "Malignant neoplasm of breast code": '254837009' from SNOMEDCT display 'Malignant neoplasm of breast'
+code "Primary malignant neoplasm of colon code": '93761005' from SNOMEDCT display 'Primary malignant neoplasm of colon'
+code "Secondary malignant neoplasm of colon code": '94260004' from SNOMEDCT display 'Secondary malignant neoplasm of colon'
+code "Carcinoma in situ of prostate (disorder) code": '92691004' from SNOMEDCT display 'Carcinoma in situ of prostate (disorder)'
+code "Small cell carcinoma of lung (disorder) code": '254632001' from SNOMEDCT display 'Small cell carcinoma of lung (disorder)'
+code "Non-small cell lung cancer (disorder) code": '254637007' from SNOMEDCT display 'Non-small cell lung cancer (disorder)'
 
 // Category code as concepts
 concept "Primary cancer": { "Primary cancer code" }
 concept "PrimaryCancersVS": {
-    "11p partial monosomy syndrome 4135001 code",
-    "Orbital lymphoma 13048006 code",
-    "Delta heavy chain disease 20224008 code",
-    "Malignant neoplasm of breast 254837009 code",
-    "Primary malignant neoplasm of colon 93761005 code",
-    "Secondary malignant neoplasm of colon 94260004 code",
-    "Carcinoma in situ of prostate (disorder) 92691004 code",
-    "Small cell carcinoma of lung (disorder) 254632001 code",
-    "Non-small cell lung cancer (disorder) 254637007 code":
+    "11p partial monosomy syndrome code",
+    "Orbital lymphoma code",
+    "Delta heavy chain disease code",
+    "Malignant neoplasm of breast code",
+    "Primary malignant neoplasm of colon code",
+    "Secondary malignant neoplasm of colon code",
+    "Carcinoma in situ of prostate (disorder) code",
+    "Small cell carcinoma of lung (disorder) code",
+    "Non-small cell lung cancer (disorder) code":
 }
 
 context Patient

--- a/public/static/cql/mCODE.cql
+++ b/public/static/cql/mCODE.cql
@@ -4,9 +4,99 @@ using FHIR version '4.0.0'
 
 // CODESYSTEMS
 codesystem "SNOMEDCT": 'http://snomed.info/sct'
+codesystem "LOINC": 'http://loinc.org'
+codesystem "OBSCAT": 'http://terminology.hl7.org/CodeSystem/observation-category'
+
+// FHIR CODES
+code "Primary cancer code": '64572001' from "SNOMEDCT" display 'Disease'
+code "TNM clinical primary tumor code": '21905-5' from "LOINC" display 'Primary tumor.clinical [Class] Cancer'
+code "TNM clinical regional nodes code": '21906-3' from "LOINC" display 'Regional lymph nodes.clinical [Class] Cancer'
+code "TNM clinical distant metastases code": '21907-1' from "LOINC" display 'Distant metastases.clinical [Class] Cancer'
+code "Tumor marker test code": 'laboratory' from "OBSCAT"
+code "Estrogen receptor code": '85337-4' from "LOINC" display 'Estrogen receptor Ag [Presence] in Breast cancer specimen by Immune stain'
+code "Progesterone receptor code": '85339-0' from "LOINC" display 'Progesterone receptor Ag [Presence] in Breast cancer specimen by Immune stain'
+code "HER2 receptor code": '85319-2' from "LOINC" display 'HER2 [Presence] in Breast cancer specimen by Immune stain'
+
+
+// Category code as concepts
+concept "Primary cancer": { "Primary cancer code" }
 
 context Patient
 
+// Copied functions from FHIRHelpers as a workaround
+// https://github.com/cqframework/clinical_quality_language/blob/master/Src/java/quick/src/main/resources/org/hl7/fhir/FHIRHelpers-4.0.0.cql
+define function ToCode(coding FHIR.Coding):
+    if coding is null then
+        null
+    else
+        System.Code {
+          code: coding.code.value,
+          system: coding.system.value,
+          version: coding.version.value,
+          display: coding.display.value
+        }
+
+define function ToConcept(concept FHIR.CodeableConcept):
+    if concept is null then
+        null
+    else
+        System.Concept {
+            codes: concept.coding C return ToCode(C),
+            display: concept.text.value
+        }
+
 // mCODE Profile Statements
-define "Patient":
-    [Patient]
+define "Primary Cancer Condition":
+    [Condition] Cancer
+    where ToConcept(Cancer.category[0] as FHIR.CodeableConcept) ~ "Primary cancer"
+
+define "TNM Clinical Primary Tumor":
+    [Observation: "TNM clinical primary tumor code"]
+
+define "TNM Clinical Regional Nodes":
+    [Observation: "TNM clinical regional nodes code"]
+
+define "TNM Clinical Distant Metastases":
+    [Observation: "TNM clinical distant metastases code"]
+
+define "Estrogen Receptor Tumor Marker Test":
+    [Observation: "Estrogen receptor code"]
+
+define "Progesterone Receptor Tumor Marker Test":
+    [Observation: "Progesterone receptor code"]
+
+define "HER2 Receptor Tumor Marker Test":
+    [Observation: "HER2 receptor code"]
+
+// mCODE Data Element Definitions
+define "Primary Cancer Condition Body Location Code":
+    "Primary Cancer Condition" Cancer
+    return Cancer.bodySite
+
+define "Primary Cancer Condition Code":
+    "Primary Cancer Condition" Cancer
+    return Cancer.code
+
+define "TNM Clinical Primary Tumor Category Data Value (T Category)":
+    "TNM Clinical Primary Tumor" Disease
+    return Disease.value.text.value
+
+define "TNM Clinical Regional Nodes Category Data Value (N Category)":
+    "TNM Clinical Regional Nodes" Disease
+    return Disease.value.text.value
+
+define "TNM Clinical Distant Metastases Category Data Value (M Category)":
+    "TNM Clinical Distant Metastases" Disease
+    return Disease.value.text.value
+
+define "Estrogen Receptor Value":
+    "Estrogen Receptor Tumor Marker Test" Test
+    return Test.value.text.value
+
+define "Progesterone Receptor Value":
+    "Progesterone Receptor Tumor Marker Test" Test
+    return Test.value.text.value
+
+define "HER2 Receptor Value":
+    "HER2 Receptor Tumor Marker Test" Test
+    return Test.value.text.value

--- a/public/static/cql/mCODE.cql
+++ b/public/static/cql/mCODE.cql
@@ -89,34 +89,34 @@ define "HER2 Receptor Tumor Marker Test":
     [Observation: "HER2 receptor code"]
 
 // mCODE Data Element Definitions
-define "Primary Cancer Condition Body Location Code":
+define "Primary Cancer Condition Value":
     "Primary Cancer Condition" Cancer
-    return Cancer.bodySite
-
-define "Primary Cancer Condition Code":
+    return Cancer.code[0].coding[0].display.value
+    
+define "Primary Cancer Condition Body Location Value":
     "Primary Cancer Condition" Cancer
-    return Cancer.code.text.value
+    return Cancer.bodySite.coding[0].display.value
 
 define "TNM Clinical Primary Tumor Category Data Value (T Category)":
     "TNM Clinical Primary Tumor" Disease
-    return Disease.value.text.value
+    return Disease.value.coding[0].display.value
 
 define "TNM Clinical Regional Nodes Category Data Value (N Category)":
     "TNM Clinical Regional Nodes" Disease
-    return Disease.value.text.value
+    return Disease.value.coding[0].display.value
 
 define "TNM Clinical Distant Metastases Category Data Value (M Category)":
     "TNM Clinical Distant Metastases" Disease
-    return Disease.value.text.value
+    return Disease.value.coding[0].display.value
 
 define "Estrogen Receptor Value":
     "Estrogen Receptor Tumor Marker Test" Test
-    return Test.value.text.value
+    return Test.value.coding[0].display.value
 
 define "Progesterone Receptor Value":
     "Progesterone Receptor Tumor Marker Test" Test
-    return Test.value.text.value
+    return Test.value.coding[0].display.value
 
 define "HER2 Receptor Value":
     "HER2 Receptor Tumor Marker Test" Test
-    return Test.value.text.value
+    return Test.value.coding[0].display.value

--- a/public/static/cql/mCODE.cql
+++ b/public/static/cql/mCODE.cql
@@ -8,7 +8,7 @@ codesystem "LOINC": 'http://loinc.org'
 codesystem "OBSCAT": 'http://terminology.hl7.org/CodeSystem/observation-category'
 
 // FHIR CODES
-code "Primary cancer code": '64572001' from "SNOMEDCT" display 'Disease'
+code "Primary cancer code": '64572001' from "SNOMEDCT" display 'Disease (disorder)'
 code "TNM clinical primary tumor code": '21905-5' from "LOINC" display 'Primary tumor.clinical [Class] Cancer'
 code "TNM clinical regional nodes code": '21906-3' from "LOINC" display 'Regional lymph nodes.clinical [Class] Cancer'
 code "TNM clinical distant metastases code": '21907-1' from "LOINC" display 'Distant metastases.clinical [Class] Cancer'
@@ -17,9 +17,31 @@ code "Estrogen receptor code": '85337-4' from "LOINC" display 'Estrogen receptor
 code "Progesterone receptor code": '85339-0' from "LOINC" display 'Progesterone receptor Ag [Presence] in Breast cancer specimen by Immune stain'
 code "HER2 receptor code": '85319-2' from "LOINC" display 'HER2 [Presence] in Breast cancer specimen by Immune stain'
 
+// selected cancer codes used within Synthea
+// not the entire list supported by PrimaryCancerConditionVS
+code "11p partial monosomy syndrome 4135001 code": '4135001' from SNOMEDCT display '11p partial monosomy syndrome'
+code "Orbital lymphoma 13048006 code": '13048006' from SNOMEDCT display 'Orbital lymphoma'
+code "Delta heavy chain disease 20224008 code": '20224008' from SNOMEDCT display 'Delta heavy chain disease'
+code "Malignant neoplasm of breast 254837009 code": '254837009' from SNOMEDCT display 'Malignant neoplasm of breast'
+code "Primary malignant neoplasm of colon 93761005 code": '93761005' from SNOMEDCT display 'Primary malignant neoplasm of colon'
+code "Secondary malignant neoplasm of colon 94260004 code": '94260004' from SNOMEDCT display 'Secondary malignant neoplasm of colon'
+code "Carcinoma in situ of prostate (disorder) 92691004 code": '92691004' from SNOMEDCT display 'Carcinoma in situ of prostate (disorder)'
+code "Small cell carcinoma of lung (disorder) 254632001 code": '254632001' from SNOMEDCT display 'Small cell carcinoma of lung (disorder)'
+code "Non-small cell lung cancer (disorder) 254637007 code": '254637007' from SNOMEDCT display 'Non-small cell lung cancer (disorder)'
 
 // Category code as concepts
 concept "Primary cancer": { "Primary cancer code" }
+concept "PrimaryCancersVS": {
+    "11p partial monosomy syndrome 4135001 code",
+    "Orbital lymphoma 13048006 code",
+    "Delta heavy chain disease 20224008 code",
+    "Malignant neoplasm of breast 254837009 code",
+    "Primary malignant neoplasm of colon 93761005 code",
+    "Secondary malignant neoplasm of colon 94260004 code",
+    "Carcinoma in situ of prostate (disorder) 92691004 code",
+    "Small cell carcinoma of lung (disorder) 254632001 code",
+    "Non-small cell lung cancer (disorder) 254637007 code":
+}
 
 context Patient
 
@@ -47,7 +69,7 @@ define function ToConcept(concept FHIR.CodeableConcept):
 
 // mCODE Profile Statements
 define "Primary Cancer Condition":
-    [Condition] Cancer
+    [Condition: code in "PrimaryCancersVS"] Cancer
     where ToConcept(Cancer.category[0] as FHIR.CodeableConcept) ~ "Primary cancer"
 
 define "TNM Clinical Primary Tumor":
@@ -75,7 +97,7 @@ define "Primary Cancer Condition Body Location Code":
 
 define "Primary Cancer Condition Code":
     "Primary Cancer Condition" Cancer
-    return Cancer.code
+    return Cancer.code.text.value
 
 define "TNM Clinical Primary Tumor Category Data Value (T Category)":
     "TNM Clinical Primary Tumor" Disease

--- a/public/static/cql/mCODE.cql
+++ b/public/static/cql/mCODE.cql
@@ -5,7 +5,6 @@ using FHIR version '4.0.0'
 // CODESYSTEMS
 codesystem "SNOMEDCT": 'http://snomed.info/sct'
 codesystem "LOINC": 'http://loinc.org'
-codesystem "OBSCAT": 'http://terminology.hl7.org/CodeSystem/observation-category'
 
 // FHIR CODES
 code "Primary cancer code": '64572001' from "SNOMEDCT" display 'Disease (disorder)'

--- a/public/static/demoData/Maureen.json
+++ b/public/static/demoData/Maureen.json
@@ -9101,14 +9101,17 @@
       ],
       "text": "Malignant neoplasm of breast (disorder)"
     },
-    "category": {
-      "coding": [
+    "category": [
         {
-          "system": "http://hl7.org/fhir/condition-category",
-          "code": "diagnosis"
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "64572001",
+              "display": "Disease"
+            }
+          ]
         }
-      ]
-    },
+    ],
     "clinicalStatus": "active",
     "verificationStatus": "confirmed",
     "onsetDateTime": "2018-10-18T22:02:14-04:00"

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -23,7 +23,6 @@ import styles from './App.module.scss';
 import { UserProvider } from './UserProvider';
 import { McodeElements } from 'mcode';
 import { getFixture } from 'engine/cql-extractor';
-import { convertBasicCQL } from 'engine/cql-to-elm';
 import executeElm from 'engine/elm-executor';
 interface AppProps {
   demoId?: string;
@@ -54,32 +53,29 @@ const App: FC<AppProps> = ({ demoId }) => {
       type: 'searchset',
       entry: resources.map((r: DomainResource) => ({ resource: r }))
     };
-    getFixture('mCODE.cql')
-      .then(cql => convertBasicCQL(cql))
-      .then(elm => {
-        const elmResults = executeElm(bundle, elm);
-        const patientIds = Object.keys(elmResults.patientResults);
-        const mcodeData = elmResults.patientResults[patientIds[0]];
+    getFixture('elm/mCODE.elm.json').then(elmString => {
+      const elm = JSON.parse(elmString);
+      const elmResults = executeElm(bundle, elm);
+      const patientIds = Object.keys(elmResults.patientResults);
+      const mcodeData = elmResults.patientResults[patientIds[0]];
 
-        const mcodeElements: McodeElements = {
-          'Primary Cancer': mcodeData['Primary Cancer Condition Code'][0] ?? undefined,
-          Laterality: mcodeData['Primary Cancer Condition Body Location Code'][0] ?? undefined,
-          'Tumor Category':
-            mcodeData['TNM Clinical Primary Tumor Category Data Value (T Category)'][0] ??
-            undefined,
-          'Node Category':
-            mcodeData['TNM Clinical Regional Nodes Category Data Value (N Category)'][0] ??
-            undefined,
-          'Metastases Category':
-            mcodeData['TNM Clinical Distant Metastases Category Data Value (M Category)'][0] ??
-            undefined,
-          'Estrogen Receptor': mcodeData['Estrogen Receptor Value'][0] ?? undefined,
-          'Progesterone Receptor': mcodeData['Progesterone Receptor Value'][0] ?? undefined,
-          'HER2 Receptor': mcodeData['HER2 Receptor Value'][0] ?? undefined
-        };
+      const mcodeElements: McodeElements = {
+        'Primary Cancer': mcodeData['Primary Cancer Condition Code'][0] ?? undefined,
+        Laterality: mcodeData['Primary Cancer Condition Body Location Code'][0] ?? undefined,
+        'Tumor Category':
+          mcodeData['TNM Clinical Primary Tumor Category Data Value (T Category)'][0] ?? undefined,
+        'Node Category':
+          mcodeData['TNM Clinical Regional Nodes Category Data Value (N Category)'][0] ?? undefined,
+        'Metastases Category':
+          mcodeData['TNM Clinical Distant Metastases Category Data Value (M Category)'][0] ??
+          undefined,
+        'Estrogen Receptor': mcodeData['Estrogen Receptor Value'][0] ?? undefined,
+        'Progesterone Receptor': mcodeData['Progesterone Receptor Value'][0] ?? undefined,
+        'HER2 Receptor': mcodeData['HER2 Receptor Value'][0] ?? undefined
+      };
 
-        _setMcodeRecords(mcodeElements);
-      });
+      _setMcodeRecords(mcodeElements);
+    });
   }, []);
 
   const providerProps = useMemo(

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -60,8 +60,8 @@ const App: FC<AppProps> = ({ demoId }) => {
       const mcodeData = elmResults.patientResults[patientIds[0]];
 
       const mcodeElements: McodeElements = {
-        'Primary Cancer': mcodeData['Primary Cancer Condition Code'][0] ?? undefined,
-        Laterality: mcodeData['Primary Cancer Condition Body Location Code'][0] ?? undefined,
+        'Primary Cancer': mcodeData['Primary Cancer Condition Value'][0] ?? undefined,
+        Laterality: mcodeData['Primary Cancer Condition Body Location Value'][0] ?? undefined,
         'Tumor Category':
           mcodeData['TNM Clinical Primary Tumor Category Data Value (T Category)'][0] ?? undefined,
         'Node Category':

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -58,7 +58,6 @@ const App: FC<AppProps> = ({ demoId }) => {
       const elmResults = executeElm(bundle, elm);
       const patientIds = Object.keys(elmResults.patientResults);
       const mcodeData = elmResults.patientResults[patientIds[0]];
-
       const mcodeElements: McodeElements = {
         'Primary Cancer': mcodeData['Primary Cancer Condition Value'][0] ?? undefined,
         Laterality: mcodeData['Primary Cancer Condition Body Location Value'][0] ?? undefined,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -57,7 +57,7 @@ const App: FC<AppProps> = ({ demoId }) => {
     getFixture('mCODE.cql')
       .then(cql => convertBasicCQL(cql))
       .then(elm => {
-        let elmResults = executeElm(bundle, elm);
+        const elmResults = executeElm(bundle, elm);
         const patientIds = Object.keys(elmResults.patientResults);
         const mcodeData = elmResults.patientResults[patientIds[0]];
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -62,20 +62,20 @@ const App: FC<AppProps> = ({ demoId }) => {
         const mcodeData = elmResults.patientResults[patientIds[0]];
 
         const mcodeElements: McodeElements = {
-          primaryCancer: mcodeData['Primary Cancer Condition Code'][0] ?? undefined,
-          laterality: mcodeData['Primary Cancer Condition Body Location Code'][0] ?? undefined,
-          tumorCategory:
+          'Primary Cancer': mcodeData['Primary Cancer Condition Code'][0] ?? undefined,
+          Laterality: mcodeData['Primary Cancer Condition Body Location Code'][0] ?? undefined,
+          'Tumor Category':
             mcodeData['TNM Clinical Primary Tumor Category Data Value (T Category)'][0] ??
             undefined,
-          nodeCategory:
+          'Node Category':
             mcodeData['TNM Clinical Regional Nodes Category Data Value (N Category)'][0] ??
             undefined,
-          metastasesCategory:
+          'Metastases Category':
             mcodeData['TNM Clinical Distant Metastases Category Data Value (M Category)'][0] ??
             undefined,
-          estrogenReceptor: mcodeData['Estrogen Receptor Value'][0] ?? undefined,
-          progesteroneReceptor: mcodeData['Progesterone Receptor Value'][0] ?? undefined,
-          her2Receptor: mcodeData['HER2 Receptor Value'][0] ?? undefined
+          'Estrogen Receptor': mcodeData['Estrogen Receptor Value'][0] ?? undefined,
+          'Progesterone Receptor': mcodeData['Progesterone Receptor Value'][0] ?? undefined,
+          'HER2 Receptor': mcodeData['HER2 Receptor Value'][0] ?? undefined
         };
 
         _setMcodeRecords(mcodeElements);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -13,7 +13,7 @@ import config from 'utils/ConfigManager';
 import PathwaysList from './PathwaysList';
 import { PathwayProvider } from './PathwayProvider';
 import ThemeProvider from './ThemeProvider';
-import { EvaluatedPathway, ElmResults } from 'pathways-model';
+import { EvaluatedPathway } from 'pathways-model';
 import useGetPathwaysService from './PathwaysService/PathwaysService';
 import FHIR from 'fhirclient';
 import { MockedFHIRClient } from 'utils/MockedFHIRClient';
@@ -57,10 +57,7 @@ const App: FC<AppProps> = ({ demoId }) => {
     getFixture('mCODE.cql')
       .then(cql => convertBasicCQL(cql))
       .then(elm => {
-        let elmResults: ElmResults = {
-          patientResults: {}
-        };
-        elmResults = executeElm(bundle, elm);
+        let elmResults = executeElm(bundle, elm);
         const patientIds = Object.keys(elmResults.patientResults);
         const mcodeData = elmResults.patientResults[patientIds[0]];
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -47,7 +47,7 @@ const App: FC<AppProps> = ({ demoId }) => {
     setEvaluatePath(true);
   }, []);
 
-  const setMcodeRecords = (resources: DomainResource[]): void => {
+  const setMcodeRecords = useCallback((resources: DomainResource[]): void => {
     // Create a Bundle for the CQL engine
     const bundle = {
       resourceType: 'Bundle',
@@ -80,10 +80,10 @@ const App: FC<AppProps> = ({ demoId }) => {
           progesteroneReceptor: mcodeData['Progesterone Receptor Value'][0] ?? undefined,
           her2Receptor: mcodeData['HER2 Receptor Value'][0] ?? undefined
         };
+
         _setMcodeRecords(mcodeElements);
-        debugger;
       });
-  };
+  }, []);
 
   const providerProps = useMemo(
     () => ({

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -138,7 +138,7 @@ const App: FC<AppProps> = ({ demoId }) => {
           setPatient(resultPatient);
         });
     }
-  }, [demoId, setPatientRecords]);
+  }, [demoId, setPatientRecords, setMcodeRecords]);
 
   // gather note info
   useEffect(() => {

--- a/src/components/PathwaysList/PathwaysList.tsx
+++ b/src/components/PathwaysList/PathwaysList.tsx
@@ -58,15 +58,15 @@ interface PathwaysListProps {
 }
 
 const PathwaysList: FC<PathwaysListProps> = ({ evaluatedPathways, callback, service }) => {
-  const resources = usePatientRecords().patientRecords;
+  const { patientRecords } = usePatientRecords();
   const [criteria, setCriteria] = useState<CriteriaResult[] | null>(null);
 
-  if (!criteria && evaluatedPathways.length > 0 && resources && resources.length > 0) {
+  if (!criteria && evaluatedPathways.length > 0 && patientRecords && patientRecords.length > 0) {
     // Create a Bundle for the CQL engine and check if patientPath needs to be evaluated
     const patient = {
       resourceType: 'Bundle',
       type: 'searchset',
-      entry: resources.map((r: fhir.Resource) => ({ resource: r }))
+      entry: patientRecords.map((r: fhir.Resource) => ({ resource: r }))
     };
 
     // Evaluate pathway criteria for each pathway
@@ -107,7 +107,7 @@ const PathwaysList: FC<PathwaysListProps> = ({ evaluatedPathways, callback, serv
 
   const getSelectedPathways = (): string[] => {
     // Get all active CarePlan resource titles
-    const carePlanTitles = (resources.filter(r => r.resourceType === 'CarePlan') as CarePlan[])
+    const carePlanTitles = (patientRecords.filter(r => r.resourceType === 'CarePlan') as CarePlan[])
       .filter(r => r.status === 'active')
       .map(r => r.title);
 

--- a/src/components/PatientRecord/PatientRecord.tsx
+++ b/src/components/PatientRecord/PatientRecord.tsx
@@ -26,9 +26,11 @@ import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { CriteriaResult } from 'pathways-model';
 import { usePathwayContext } from 'components/PathwayProvider';
 import { evaluatePathwayCriteria } from 'engine';
+import { McodeElements } from 'mcode';
 
 const resourceTypes = [
   'Pathway',
+  'Mcode',
   'Patient',
   'Condition',
   'Observation',
@@ -124,10 +126,12 @@ const PatientRecord: FC<PatientRecordProps> = ({ headerElement }) => {
 };
 
 const PatientRecordElement: FC<PatientRecordElementProps> = ({ resourceType, resources }) => {
+  console.log(resourceType);
+  console.log(resources);
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
   const chevron: IconProp = isExpanded ? faChevronUp : faChevronDown;
-  const resourceCount: string = !['Patient', 'Pathway'].includes(resourceType)
+  const resourceCount: string = !['Patient', 'Pathway', 'Mcode'].includes(resourceType)
     ? `(${resources.length})`
     : '';
 
@@ -155,6 +159,7 @@ const Visualizer: FC<VisualizerProps> = ({ resourceType, resourcesByType }) => {
   const patient = usePatient().patient as fhir.Patient;
 
   if (resourceType === 'Pathway') return <PathwayVisualizer />;
+  else if (resourceType === 'Mcode') return <McodeVisualizer />;
   else if (resourceType === 'Patient') return <PatientVisualizer patient={patient} />;
   else if (resourceType === 'Condition') return <ConditionsVisualizer rows={resourcesByType} />;
   else if (resourceType === 'Observation') return <ObservationsVisualizer rows={resourcesByType} />;
@@ -201,6 +206,30 @@ const PathwayVisualizer: FC = () => {
             <td>{c.actual}</td>
           </tr>
         ))}
+      </tbody>
+    </table>
+  );
+};
+
+const McodeVisualizer: FC = () => {
+  const mcode = usePatientRecords().mcodeRecords;
+  console.log(mcode);
+  type mcodeKey = keyof McodeElements & string;
+  const keysArray: mcodeKey[] = [];
+  for (const key in mcode) {
+    keysArray.push(key as mcodeKey);
+  }
+  return (
+    <table>
+      <tbody>
+        {keysArray.map(key => {
+          return (
+            <tr key={key}>
+              <td>{key}</td>
+              <td>{mcode[key] ? mcode[key] : '-'}</td>
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   );

--- a/src/components/PatientRecord/PatientRecord.tsx
+++ b/src/components/PatientRecord/PatientRecord.tsx
@@ -80,10 +80,10 @@ interface VisualizerProps {
 }
 
 const PatientRecord: FC<PatientRecordProps> = ({ headerElement }) => {
-  const resources = usePatientRecords().patientRecords;
+  const { patientRecords } = usePatientRecords();
   const recordContainerElement = useRef<HTMLDivElement>(null);
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
-  const groupedResources = groupResourceByType(resources);
+  const groupedResources = groupResourceByType(patientRecords);
 
   const expand = (): void => {
     setIsExpanded(!isExpanded);
@@ -126,8 +126,6 @@ const PatientRecord: FC<PatientRecordProps> = ({ headerElement }) => {
 };
 
 const PatientRecordElement: FC<PatientRecordElementProps> = ({ resourceType, resources }) => {
-  console.log(resourceType);
-  console.log(resources);
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
   const chevron: IconProp = isExpanded ? faChevronUp : faChevronDown;
@@ -177,8 +175,8 @@ const Visualizer: FC<VisualizerProps> = ({ resourceType, resourcesByType }) => {
 };
 
 const PathwayVisualizer: FC = () => {
-  const resources = usePatientRecords().patientRecords;
-  const evaluatedPathway = usePathwayContext().evaluatedPathway;
+  const { patientRecords } = usePatientRecords();
+  const { evaluatedPathway } = usePathwayContext();
   const [criteria, setCriteria] = useState<CriteriaResult | null>(null);
 
   useEffect(() => {
@@ -186,7 +184,7 @@ const PathwayVisualizer: FC = () => {
     const patient = {
       resourceType: 'Bundle',
       type: 'searchset',
-      entry: resources.map((r: fhir.Resource) => ({ resource: r }))
+      entry: patientRecords.map((r: fhir.Resource) => ({ resource: r }))
     };
 
     // Evaluate pathway criteria
@@ -195,7 +193,7 @@ const PathwayVisualizer: FC = () => {
         setCriteria(criteriaResult)
       );
     }
-  }, [evaluatedPathway, resources]);
+  }, [evaluatedPathway, patientRecords]);
 
   return (
     <table>
@@ -212,21 +210,22 @@ const PathwayVisualizer: FC = () => {
 };
 
 const McodeVisualizer: FC = () => {
-  const mcode = usePatientRecords().mcodeRecords;
-  console.log(mcode);
+  const { mcodeRecords } = usePatientRecords();
   type mcodeKey = keyof McodeElements & string;
   const keysArray: mcodeKey[] = [];
-  for (const key in mcode) {
+  for (const key in mcodeRecords) {
     keysArray.push(key as mcodeKey);
   }
   return (
     <table>
       <tbody>
         {keysArray.map(key => {
+          const result = key.replace(/([A-Z]+)*([A-Z][a-z])/g, '$1 $2');
+          const name = result.charAt(0).toUpperCase() + result.slice(1);
           return (
             <tr key={key}>
-              <td>{key}</td>
-              <td>{mcode[key] ? mcode[key] : '-'}</td>
+              <td>{name}</td>
+              <td>{mcodeRecords[key] ? mcodeRecords[key] : '-'}</td>
             </tr>
           );
         })}

--- a/src/components/PatientRecord/PatientRecord.tsx
+++ b/src/components/PatientRecord/PatientRecord.tsx
@@ -28,7 +28,7 @@ import { usePathwayContext } from 'components/PathwayProvider';
 import { evaluatePathwayCriteria } from 'engine';
 import { McodeElements } from 'mcode';
 
-const resourceTypes = [
+const recordSections = [
   'Pathway',
   'Mcode',
   'Patient',
@@ -49,7 +49,7 @@ const groupResourceByType = (
   const map: Map<string, DomainResource[]> = new Map();
   patientRecord.forEach(resource => {
     const resourceType = resource.resourceType ?? '';
-    if (resourceTypes.includes(resourceType)) {
+    if (recordSections.includes(resourceType)) {
       const collection = map.get(resourceType);
       if (!collection) map.set(resourceType, [resource]);
       else collection.push(resource);
@@ -70,12 +70,12 @@ interface PatientRecordProps {
 }
 
 interface PatientRecordElementProps {
-  resourceType: string;
+  recordSection: string;
   resources: ReadonlyArray<DomainResource>;
 }
 
 interface VisualizerProps {
-  resourceType: string;
+  recordSection: string;
   resourcesByType: ReadonlyArray<DomainResource>;
 }
 
@@ -100,11 +100,11 @@ const PatientRecord: FC<PatientRecordProps> = ({ headerElement }) => {
     return (
       <div className={styles.record} ref={recordContainerElement}>
         <div className={styles.sidebar}>
-          {resourceTypes.map(resourceType => (
+          {recordSections.map(recordSection => (
             <PatientRecordElement
-              resourceType={resourceType}
-              resources={getResourcesByType(resourceType, groupedResources)}
-              key={resourceType}
+              recordSection={recordSection}
+              resources={getResourcesByType(recordSection, groupedResources)}
+              key={recordSection}
             />
           ))}
         </div>
@@ -125,11 +125,11 @@ const PatientRecord: FC<PatientRecordProps> = ({ headerElement }) => {
   }
 };
 
-const PatientRecordElement: FC<PatientRecordElementProps> = ({ resourceType, resources }) => {
+const PatientRecordElement: FC<PatientRecordElementProps> = ({ recordSection, resources }) => {
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
   const chevron: IconProp = isExpanded ? faChevronUp : faChevronDown;
-  const resourceCount: string = !['Patient', 'Pathway', 'Mcode'].includes(resourceType)
+  const resourceCount: string = !['Patient', 'Pathway', 'Mcode'].includes(recordSection)
     ? `(${resources.length})`
     : '';
 
@@ -137,7 +137,7 @@ const PatientRecordElement: FC<PatientRecordElementProps> = ({ resourceType, res
     <div className={styles.element}>
       <div className={styles.title} onClick={(): void => setIsExpanded(!isExpanded)}>
         <div>
-          {resourceType} {resourceCount}
+          {recordSection} {resourceCount}
         </div>
         <div className={styles.expand}>
           <FontAwesomeIcon icon={chevron} />
@@ -146,30 +146,32 @@ const PatientRecordElement: FC<PatientRecordElementProps> = ({ resourceType, res
 
       {isExpanded && (
         <div className={styles.visualizerContainer}>
-          <Visualizer resourceType={resourceType} resourcesByType={resources} />
+          <Visualizer recordSection={recordSection} resourcesByType={resources} />
         </div>
       )}
     </div>
   );
 };
 
-const Visualizer: FC<VisualizerProps> = ({ resourceType, resourcesByType }) => {
+const Visualizer: FC<VisualizerProps> = ({ recordSection, resourcesByType }) => {
   const patient = usePatient().patient as fhir.Patient;
 
-  if (resourceType === 'Pathway') return <PathwayVisualizer />;
-  else if (resourceType === 'Mcode') return <McodeVisualizer />;
-  else if (resourceType === 'Patient') return <PatientVisualizer patient={patient} />;
-  else if (resourceType === 'Condition') return <ConditionsVisualizer rows={resourcesByType} />;
-  else if (resourceType === 'Observation') return <ObservationsVisualizer rows={resourcesByType} />;
-  else if (resourceType === 'DiagnosticReport') return <ReportsVisualizer rows={resourcesByType} />;
-  else if (resourceType === 'MedicationRequest')
+  if (recordSection === 'Pathway') return <PathwayVisualizer />;
+  else if (recordSection === 'Mcode') return <McodeVisualizer />;
+  else if (recordSection === 'Patient') return <PatientVisualizer patient={patient} />;
+  else if (recordSection === 'Condition') return <ConditionsVisualizer rows={resourcesByType} />;
+  else if (recordSection === 'Observation')
+    return <ObservationsVisualizer rows={resourcesByType} />;
+  else if (recordSection === 'DiagnosticReport')
+    return <ReportsVisualizer rows={resourcesByType} />;
+  else if (recordSection === 'MedicationRequest')
     return <MedicationsVisualizer rows={resourcesByType} />;
-  else if (resourceType === 'AllergyIntolerance')
+  else if (recordSection === 'AllergyIntolerance')
     return <AllergiesVisualizer rows={resourcesByType} />;
-  else if (resourceType === 'CarePlan') return <CarePlansVisualizer rows={resourcesByType} />;
-  else if (resourceType === 'Procedure') return <ProceduresVisualizer rows={resourcesByType} />;
-  else if (resourceType === 'Encounter') return <EncountersVisualizer rows={resourcesByType} />;
-  else if (resourceType === 'Immunization')
+  else if (recordSection === 'CarePlan') return <CarePlansVisualizer rows={resourcesByType} />;
+  else if (recordSection === 'Procedure') return <ProceduresVisualizer rows={resourcesByType} />;
+  else if (recordSection === 'Encounter') return <EncountersVisualizer rows={resourcesByType} />;
+  else if (recordSection === 'Immunization')
     return <ImmunizationsVisualizer rows={resourcesByType} />;
   else return <div>Unsupported Resource</div>;
 };

--- a/src/components/PatientRecord/PatientRecord.tsx
+++ b/src/components/PatientRecord/PatientRecord.tsx
@@ -220,11 +220,9 @@ const McodeVisualizer: FC = () => {
     <table>
       <tbody>
         {keysArray.map(key => {
-          const result = key.replace(/([A-Z]+)*([A-Z][a-z])/g, '$1 $2');
-          const name = result.charAt(0).toUpperCase() + result.slice(1);
           return (
             <tr key={key}>
-              <td>{name}</td>
+              <td>{key}</td>
               <td>{mcodeRecords[key] ? mcodeRecords[key] : '-'}</td>
             </tr>
           );

--- a/src/components/PatientRecordsProvider.tsx
+++ b/src/components/PatientRecordsProvider.tsx
@@ -1,5 +1,6 @@
 import React, { FC, createContext, useContext, ReactNode } from 'react';
 import { DomainResource } from 'fhir-objects';
+import { McodeElements } from 'mcode';
 interface PatientRecordsProviderProps {
   children: ReactNode;
   value: PatientRecordsContextInterface;
@@ -10,6 +11,8 @@ interface PatientRecordsContextInterface {
   setPatientRecords: Function;
   evaluatePath: boolean;
   setEvaluatePath: (value: boolean) => void;
+  mcodeRecords: McodeElements;
+  setMcodeRecords: (value: DomainResource[]) => void;
 }
 
 export const PatientRecordsContext = createContext<PatientRecordsContextInterface>({
@@ -19,6 +22,10 @@ export const PatientRecordsContext = createContext<PatientRecordsContextInterfac
   },
   evaluatePath: true,
   setEvaluatePath: (): void => {
+    return;
+  },
+  mcodeRecords: {},
+  setMcodeRecords: (): void => {
     return;
   }
 });

--- a/src/components/ReportModal/ReportModal.tsx
+++ b/src/components/ReportModal/ReportModal.tsx
@@ -4,6 +4,8 @@ import ReportSection, { PhysicianNotesSection } from './ReportSection';
 import styles from './ReportModal.module.scss';
 import { faUser, faNotesMedical, faRoute, faStickyNote } from '@fortawesome/free-solid-svg-icons';
 import ActionButton from 'components/ActionButton';
+import { usePatientRecords } from 'components/PatientRecordsProvider';
+import { getTNM } from 'utils/fhirUtils';
 
 interface ReportModalInterface {
   onConfirm: () => void;
@@ -12,6 +14,7 @@ interface ReportModalInterface {
 
 const ReportModal: FC<ReportModalInterface> = ({ onConfirm, onDecline }) => {
   const { note } = useNote();
+  const { mcodeRecords } = usePatientRecords();
   const reportName = 'Pathway Report';
   const patientSection = [
     { name: 'Date', value: note?.date },
@@ -21,12 +24,12 @@ const ReportModal: FC<ReportModalInterface> = ({ onConfirm, onDecline }) => {
   ];
 
   const observationField = [
-    { name: 'Primary Cancer', value: undefined },
-    { name: 'Laterality', value: undefined },
-    { name: 'Clinical TNM', value: undefined },
-    { name: 'Estrogen Receptor', value: undefined },
-    { name: 'Progesterone Receptor', value: undefined },
-    { name: 'HER2 Receptor', value: undefined }
+    { name: 'Primary Cancer', value: mcodeRecords.primaryCancer ?? 'Unknown' },
+    { name: 'Laterality', value: mcodeRecords.laterality ?? 'Unknown' },
+    { name: 'Clinical TNM', value: getTNM(mcodeRecords) },
+    { name: 'Estrogen Receptor', value: mcodeRecords.estrogenReceptor ?? 'Unknown' },
+    { name: 'Progesterone Receptor', value: mcodeRecords.progesteroneReceptor ?? 'Unknown' },
+    { name: 'HER2 Receptor', value: mcodeRecords.her2Receptor ?? 'Unknown' }
   ];
 
   const pathwaySection = [

--- a/src/components/ReportModal/ReportModal.tsx
+++ b/src/components/ReportModal/ReportModal.tsx
@@ -24,12 +24,12 @@ const ReportModal: FC<ReportModalInterface> = ({ onConfirm, onDecline }) => {
   ];
 
   const observationField = [
-    { name: 'Primary Cancer', value: mcodeRecords.primaryCancer ?? 'Unknown' },
-    { name: 'Laterality', value: mcodeRecords.laterality ?? 'Unknown' },
+    { name: 'Primary Cancer', value: mcodeRecords['Primary Cancer'] ?? 'Unknown' },
+    { name: 'Laterality', value: mcodeRecords.Laterality ?? 'Unknown' },
     { name: 'Clinical TNM', value: getTNM(mcodeRecords) },
-    { name: 'Estrogen Receptor', value: mcodeRecords.estrogenReceptor ?? 'Unknown' },
-    { name: 'Progesterone Receptor', value: mcodeRecords.progesteroneReceptor ?? 'Unknown' },
-    { name: 'HER2 Receptor', value: mcodeRecords.her2Receptor ?? 'Unknown' }
+    { name: 'Estrogen Receptor', value: mcodeRecords['Estrogen Receptor'] ?? 'Unknown' },
+    { name: 'Progesterone Receptor', value: mcodeRecords['Progesterone Receptor'] ?? 'Unknown' },
+    { name: 'HER2 Receptor', value: mcodeRecords['HER2 Receptor'] ?? 'Unknown' }
   ];
 
   const pathwaySection = [

--- a/src/engine/evaluate-patient.ts
+++ b/src/engine/evaluate-patient.ts
@@ -85,9 +85,7 @@ function processELMCommon(patientRecord: Bundle, elm: object): Promise<PatientDa
   // this is not inherently async,
   // but we wrap it in a promise to make the code cleaner elsewhere
   return new Promise((resolve, reject) => {
-    let elmResults: ElmResults = {
-      patientResults: {}
-    };
+    let elmResults: ElmResults;
     if (instanceOfElmObject(elm)) {
       elmResults = executeElm(patientRecord, elm.main, elm.libraries);
     } else {

--- a/src/testUtils/MockedPathwayProvider.tsx
+++ b/src/testUtils/MockedPathwayProvider.tsx
@@ -9,7 +9,7 @@ interface PathwayProviderProps {
 
 const pathway: Pathway = {
   name: 'Test Pathway',
-  library: 'mCODE.cql',
+  library: 'mCODE_Library.cql',
   criteria: [
     {
       elementName: 'condition',

--- a/src/testUtils/MockedPatientRecordsProvider.tsx
+++ b/src/testUtils/MockedPatientRecordsProvider.tsx
@@ -27,6 +27,10 @@ const MockedPatientRecordsProvider: FC<PatientRecordsProviderProps> = ({ childre
       evaluatePath: true,
       setEvaluatePath: (): void => {
         return;
+      },
+      mcodeRecords: {},
+      setMcodeRecords: (): void => {
+        return;
       }
     }}
   >

--- a/src/types/fhir-objects.d.ts
+++ b/src/types/fhir-objects.d.ts
@@ -19,4 +19,5 @@ declare module 'fhir-objects' {
   export type ServiceRequest = fhir.ProcedureRequest | R4.IServiceRequest;
   export type MedicationRequest = fhir.MedicationRequest | R4.IMedicationRequest;
   export type CarePlan = R4.ICarePlan;
+  export type Condition = fhir.Condition;
 }

--- a/src/types/mcode.d.ts
+++ b/src/types/mcode.d.ts
@@ -1,13 +1,13 @@
 declare module 'mcode' {
   import { Condition, Observation } from 'fhir-objects';
   export interface McodeElements {
-    primaryCancer?: string;
-    laterality?: string;
-    tumorCategory?: string;
-    nodeCategory?: string;
-    metastasesCategory?: string;
-    estrogenReceptor?: string;
-    progesteroneReceptor?: string;
-    her2Receptor?: string;
+    'Primary Cancer'?: string;
+    Laterality?: string;
+    'Tumor Category'?: string;
+    'Node Category'?: string;
+    'Metastases Category'?: string;
+    'Estrogen Receptor'?: string;
+    'Progesterone Receptor'?: string;
+    'HER2 Receptor'?: string;
   }
 }

--- a/src/types/mcode.d.ts
+++ b/src/types/mcode.d.ts
@@ -1,0 +1,13 @@
+declare module 'mcode' {
+  import { Condition, Observation } from 'fhir-objects';
+  export interface McodeElements {
+    primaryCancer?: string;
+    laterality?: string;
+    tumorCategory?: string;
+    nodeCategory?: string;
+    metastasesCategory?: string;
+    estrogenReceptor?: string;
+    progesteroneReceptor?: string;
+    her2Receptor?: string;
+  }
+}

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -215,9 +215,9 @@ export function createCarePlan(title: string, patient: Patient): CarePlan {
 
 export function getTNM(mcodeElements: McodeElements): string {
   const tnm = [
-    mcodeElements.tumorCategory?.split(' ')[0],
-    mcodeElements.nodeCategory?.split(' ')[0],
-    mcodeElements.metastasesCategory?.split(' ')[0]
+    mcodeElements['Tumor Category']?.split(' ')[0],
+    mcodeElements['Node Category']?.split(' ')[0],
+    mcodeElements['Metastases Category']?.split(' ')[0]
   ].join(' ');
   return tnm === '   ' ? 'Unknown' : tnm;
 }

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -214,11 +214,10 @@ export function createCarePlan(title: string, patient: Patient): CarePlan {
 }
 
 export function getTNM(mcodeElements: McodeElements): string {
-  let tnm = '';
-  tnm += mcodeElements.tumorCategory?.split(' ')[0] ?? '';
-  tnm += ' ';
-  tnm += mcodeElements.nodeCategory?.split(' ')[0] ?? '';
-  tnm += ' ';
-  tnm += mcodeElements.metastasesCategory?.split(' ')[0] ?? '';
-  return tnm;
+  const tnm = [
+    mcodeElements.tumorCategory?.split(' ')[0],
+    mcodeElements.nodeCategory?.split(' ')[0],
+    mcodeElements.metastasesCategory?.split(' ')[0]
+  ].join(' ');
+  return tnm === '   ' ? 'Unknown' : tnm;
 }

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -12,6 +12,7 @@ import {
 } from 'fhir-objects';
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { v1 } from 'uuid';
+import { McodeElements } from 'mcode';
 
 // translates pathway recommendation resource into suitable FHIR resource
 export function translatePathwayRecommendation(
@@ -210,4 +211,14 @@ export function createCarePlan(title: string, patient: Patient): CarePlan {
     ],
     subject: { reference: `Patient/${patient.id}` }
   };
+}
+
+export function getTNM(mcodeElements: McodeElements): string {
+  let tnm = '';
+  tnm += mcodeElements.tumorCategory?.split(' ')[0] ?? '';
+  tnm += ' ';
+  tnm += mcodeElements.nodeCategory?.split(' ')[0] ?? '';
+  tnm += ' ';
+  tnm += mcodeElements.metastasesCategory?.split(' ')[0] ?? '';
+  return tnm;
 }


### PR DESCRIPTION
Creates a new CQL file to grab mCODE data from the patient record and then make it available in the patient provider. Then it uses this data to populate the report modal.

![Screen Shot 2020-04-23 at 2 35 14 PM](https://user-images.githubusercontent.com/53485517/80136412-a7b8ed80-856f-11ea-8f4f-91bccc0cd66d.png)


Putting this PR up now for comments but Keeyan's branch should be merged into this first.
Note: eslint fails but this is fixed by Keeyan's PR