### PR TITLE
Fix Node Status Bug

### DIFF
--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -91,7 +91,8 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
         : null;
       let status = null;
       if ('action' in pathwayState) {
-        status = isAccepted;
+        if (isOnPatientPath) status = isAccepted;
+        else status = isGuidance && documentation ? true : null;
       } else if (!isCurrentNode && documentation) {
         status = true;
       }


### PR DESCRIPTION
There was a bug where action nodes were incorrectly showing status for nodes not on the current path. Previously the Chemotherapy nodes for the HER2 pathway had documentation when expanded but did not mark themselves as complete on the status icon.
![Screen Shot 2020-04-27 at 2 29 29 PM](https://user-images.githubusercontent.com/53485517/80407372-83248480-8893-11ea-8d53-0eb1f521c324.png)
Note: Use demo patient Maryam