### PR TITLE
make scrollables modify height on rerender

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -158,10 +158,11 @@ const App: FC<AppProps> = ({ demoId }) => {
 
   // Set the height of the graph container
   useEffect(() => {
-    if (graphContainerElement?.current && headerElement?.current)
+    if (graphContainerElement?.current && headerElement?.current) {
       graphContainerElement.current.style.height =
         window.innerHeight - headerElement.current.clientHeight + 'px';
-  }, [selectPathway]);
+    }
+  });
 
   function setEvaluatedPathwayCallback(
     value: EvaluatedPathway | null,
@@ -217,6 +218,7 @@ const App: FC<AppProps> = ({ demoId }) => {
                     evaluatedPathways={evaluatedPathways}
                     callback={setEvaluatedPathwayCallback}
                     service={service}
+                    headerElement={headerElement}
                   />
                 ) : (
                   <PatientView

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -162,7 +162,7 @@ const App: FC<AppProps> = ({ demoId }) => {
       graphContainerElement.current.style.height =
         window.innerHeight - headerElement.current.clientHeight + 'px';
     }
-  });
+  }, [selectPathway]);
 
   function setEvaluatedPathwayCallback(
     value: EvaluatedPathway | null,

--- a/src/components/PathwaysList/PathwaysList.module.scss
+++ b/src/components/PathwaysList/PathwaysList.module.scss
@@ -117,6 +117,8 @@ $lineHeight: 35px;
 }
 
 .pathways_list {
+  overflow-y: auto;
+
   .header_title {
     display: flex;
     flex-direction: column;

--- a/src/components/PathwaysList/PathwaysList.tsx
+++ b/src/components/PathwaysList/PathwaysList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useState, ButtonHTMLAttributes } from 'react';
+import React, { FC, ReactNode, useState, ButtonHTMLAttributes, RefObject } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
 import { Service } from 'pathways-objects';
@@ -55,9 +55,15 @@ interface PathwaysListProps {
   evaluatedPathways: EvaluatedPathway[];
   callback: Function;
   service: Service<Array<Pathway>>;
+  headerElement: RefObject<HTMLDivElement>;
 }
 
-const PathwaysList: FC<PathwaysListProps> = ({ evaluatedPathways, callback, service }) => {
+const PathwaysList: FC<PathwaysListProps> = ({
+  evaluatedPathways,
+  callback,
+  service,
+  headerElement
+}) => {
   const { patientRecords } = usePatientRecords();
   const [criteria, setCriteria] = useState<CriteriaResult[] | null>(null);
 
@@ -120,8 +126,12 @@ const PathwaysList: FC<PathwaysListProps> = ({ evaluatedPathways, callback, serv
   };
 
   const selectedPathways = getSelectedPathways();
+  const style = { height: '100%' };
+  if (headerElement?.current) {
+    style.height = window.innerHeight - headerElement.current.clientHeight + 'px';
+  }
   return (
-    <div className={styles.pathways_list}>
+    <div className={styles.pathways_list} style={style}>
       {service.status === 'loading' ? (
         <div>Loading...</div>
       ) : service.status === 'loaded' ? (


### PR DESCRIPTION
Basically, a specific `useEffect` hook wouldn't fire on rerender and the `height` style simply wouldn't be set on the div, so it would just stretch to fit all the content, making the body scroll instead, leaving the header behind.  

The way I fixed it was to make the `useEffect` run every render by removing the dependency list.  I did the same thing for the `PathwayList` since it would leave the header behind as well when the body scrolled.

There could a more elegant solution using CSS, since our real problem is that we want the divs that contain the content to have a max-height equal to the size of the window minus the size of the header.  If the header was a consistent size (perhaps a function of vh) then the containers could also have a consistent max-height.