### PR TITLE
Fix unmounting bug

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import React, { FC, useState, useEffect, useCallback, useMemo, useRef, RefObject } from 'react';
 import Header from 'components/Header';
 import Navigation from 'components/Navigation';
 import { PathwaysClient } from 'pathways-client';
@@ -189,30 +189,6 @@ const App: FC<AppProps> = ({ demoId }) => {
     [currentPathway, evaluatedPathways]
   );
 
-  interface PatientViewProps {
-    evaluatedPathway: EvaluatedPathway | null;
-  }
-
-  const PatientView: FC<PatientViewProps> = ({ evaluatedPathway }) => {
-    return (
-      <div className={styles.display}>
-        <PatientRecord headerElement={headerElement} />
-
-        {evaluatedPathway ? (
-          <div ref={graphContainerElement} className={styles.graph}>
-            <Graph
-              evaluatedPathway={evaluatedPathway}
-              expandCurrentNode={true}
-              updateEvaluatedPathways={updateEvaluatedPathways}
-            />
-          </div>
-        ) : (
-          <div>No Pathway Loaded</div>
-        )}
-      </div>
-    );
-  };
-
   return (
     <ThemeProvider>
       <FHIRClientProvider client={client as PathwaysClient}>
@@ -243,7 +219,12 @@ const App: FC<AppProps> = ({ demoId }) => {
                     service={service}
                   />
                 ) : (
-                  <PatientView evaluatedPathway={currentPathway} />
+                  <PatientView
+                    headerElement={headerElement}
+                    graphContainerElement={graphContainerElement}
+                    evaluatedPathway={currentPathway}
+                    updateEvaluatedPathways={updateEvaluatedPathways}
+                  />
                 )}
               </PathwayProvider>
             </PatientRecordsProvider>
@@ -251,6 +232,38 @@ const App: FC<AppProps> = ({ demoId }) => {
         </UserProvider>
       </FHIRClientProvider>
     </ThemeProvider>
+  );
+};
+
+interface PatientViewProps {
+  headerElement: RefObject<HTMLDivElement>;
+  graphContainerElement: RefObject<HTMLDivElement>;
+  evaluatedPathway: EvaluatedPathway | null;
+  updateEvaluatedPathways: (value: EvaluatedPathway) => void;
+}
+
+const PatientView: FC<PatientViewProps> = ({
+  headerElement,
+  graphContainerElement,
+  evaluatedPathway,
+  updateEvaluatedPathways
+}) => {
+  return (
+    <div className={styles.display}>
+      <PatientRecord headerElement={headerElement} />
+
+      {evaluatedPathway ? (
+        <div ref={graphContainerElement} className={styles.graph}>
+          <Graph
+            evaluatedPathway={evaluatedPathway}
+            expandCurrentNode={true}
+            updateEvaluatedPathways={updateEvaluatedPathways}
+          />
+        </div>
+      ) : (
+        <div>No Pathway Loaded</div>
+      )}
+    </div>
   );
 };
 


### PR DESCRIPTION
So this is a bug I just fixed in the pathway builder. 
Behavior: first open the sidebar. Then accept a node or add missing data. Not only will the graph re-render overflowing its original container but the sidebar will also collapse even though it was already expanded.
Cause: the entire PatientView container is being unmounted and then a new one is being created (with the sidebar closed by default). I believe this is because the PatientView component is defined within the App component. Thus, whenever the App re-render (ie: the App state changes from accepting a node) the old PatientView ceases to exist and a brand new one is created. 
Solution: Move the PatientView component outside of the App component but still in App.tsx

This not only fixes the weird sidebar behavior but also prevents the bug Keeyan has been dealing with regarding the Graph container overflowing and not scrolling anymore on re-render. I also assume there is a decent speedup between re-rendering versus the previous unmounting and remounting