### PR TITLE
Bugfixes

### DIFF
--- a/public/static/pathways/her2_pathway.json
+++ b/public/static/pathways/her2_pathway.json
@@ -1,5 +1,5 @@
 {
-  "name": "Early Stage HER2+ (Draft)",
+  "name": "Breast Cancer: Early Stage HER2+ (Draft)",
   "description": "Pathway for the Early Stage HER2+ Initial Medical Consult Breast Cancer Pathway. This is a draft pathway.",
   "library": "mCODE_Library.cql",
   "criteria": [

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -222,6 +222,7 @@ const App: FC<AppProps> = ({ demoId }) => {
                   />
                 ) : (
                   <PatientView
+                    key={currentPathway?.pathway.name ?? ''}
                     headerElement={headerElement}
                     graphContainerElement={graphContainerElement}
                     evaluatedPathway={currentPathway}

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -76,6 +76,7 @@ const ExpandedNode: FC<ExpandedNodeProps> = memo(
       }
 
       setPatientRecords(newPatientRecords);
+      setShowReport(false);
     };
 
     return (

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -137,7 +137,7 @@ const Graph: FC<GraphProps> = memo(
 
     const setExpanded = useCallback((key: string, expand?: boolean): void => {
       _setExpanded(prevState => {
-        return { ...prevState, [key]: !prevState[key] };
+        return { ...prevState, [key]: expand ?? !prevState[key] };
       });
     }, []);
 


### PR DESCRIPTION
Fixes a few bugs:
1. Pathway switcher dropdown doesn't work
2. Current node isn't automatically expanded on first open
3. Pathway report doesn't automatically close on accept

One new bug that I think this introduces is that when taking action on a node in a way that changes the active nodes, for example entering missing data or accepting one action of multiple, the old previously active state is no longer automatically closed, it's left open. Not sure if there's a quick fix for that. But it also minimizes the amount of jumping around in the app so maybe it's not the worst thing in the world