### PR TITLE
Force move to next state

### DIFF
--- a/src/components/ExpandedNode/ExpandedNode.module.scss
+++ b/src/components/ExpandedNode/ExpandedNode.module.scss
@@ -29,7 +29,7 @@
   }
 }
 
-.defaultTextButton {
+.button {
     padding: 5px 10px;
     margin: 0 0 2px 5px;
     float: right;

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -90,13 +90,11 @@ const ExpandedNode: FC<ExpandedNodeProps> = memo(
     };
 
     const onAdvance = (): void => {
-      const newPatientRecords = [...patientRecords];
       const content = `${pathwayState.label} - Advance`;
       const documentReference = createDocumentReference(content, patient);
 
-      newPatientRecords.push(documentReference);
       client?.create?.(documentReference);
-      setPatientRecords(newPatientRecords);
+      setPatientRecords([...patientRecords, documentReference]);
     };
 
     return (

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -12,6 +12,7 @@ import { usePatientRecords } from 'components/PatientRecordsProvider';
 import { usePatient } from 'components/PatientProvider';
 import {
   translatePathwayRecommendation,
+  createActionDocumentReference,
   createDocumentReference,
   createNoteContent
 } from 'utils/fhirUtils';
@@ -63,7 +64,12 @@ const ExpandedNode: FC<ExpandedNodeProps> = memo(
           note?.notes ?? '',
           pathwayState
         );
-        const documentReference = createDocumentReference(noteString, pathwayState.label, patient);
+        const documentReference = createActionDocumentReference(
+          noteString,
+          pathwayState.label,
+          patient
+        );
+
         newPatientRecords.push(documentReference);
         client?.create?.(documentReference);
       }
@@ -85,29 +91,8 @@ const ExpandedNode: FC<ExpandedNodeProps> = memo(
 
     const onAdvance = (): void => {
       const newPatientRecords = [...patientRecords];
-
-      const documentReference: DocumentReference = {
-        resourceType: 'DocumentReference',
-        status: 'current',
-        content: [
-          {
-            attachment: {
-              data: btoa(`${pathwayState.label} - Advance`),
-              contentType: 'text/plain'
-            }
-          }
-        ],
-        type: {
-          coding: [
-            {
-              system: 'http://loinc.org',
-              code: '34108-1',
-              display: 'Outpatient Note'
-            }
-          ]
-        },
-        indexed: ''
-      };
+      const content = `${pathwayState.label} - Advance`;
+      const documentReference = createDocumentReference(content, patient);
 
       newPatientRecords.push(documentReference);
       client?.create?.(documentReference);

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -29,7 +29,7 @@ import {
   ServiceRequest,
   CarePlan
 } from 'fhir-objects';
-import { Button } from '@material-ui/core';
+
 interface ExpandedNodeProps {
   pathwayState: GuidanceState;
   isActionable: boolean;

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -414,7 +414,7 @@ const ExpandedNodeMemo: FC<ExpandedNodeMemoProps> = memo(
         </table>
         {/* Node is advanceable if it has been accepted or declined */}
         {pathwayState.transitions.length > 0 && !isActionable && isGuidance && isCurrentNode && (
-          <button className={indexStyles.button} onClick={onAdvance}>
+          <button className={`${indexStyles.button} ${styles.button}`} onClick={onAdvance}>
             Advance
           </button>
         )}
@@ -423,7 +423,7 @@ const ExpandedNodeMemo: FC<ExpandedNodeMemoProps> = memo(
             <div>
               <label>Comments:</label>
               <Button
-                className={`${indexStyles.button} ${styles.defaultTextButton}`}
+                className={`${indexStyles.button} ${styles.button}`}
                 onClick={(e): void => {
                   e.preventDefault();
                   if (!comments.includes(defaultText)) setComments(comments + defaultText);

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -31,13 +31,14 @@ import { Button } from '@material-ui/core';
 interface ExpandedNodeProps {
   pathwayState: GuidanceState;
   isActionable: boolean;
+  isCurrentNode: boolean;
   isGuidance: boolean;
   documentation: DocumentationResource | undefined;
   isAccepted: boolean | null;
 }
 
 const ExpandedNode: FC<ExpandedNodeProps> = memo(
-  ({ pathwayState, isActionable, isGuidance, documentation, isAccepted }) => {
+  ({ pathwayState, isActionable, isCurrentNode, isGuidance, documentation, isAccepted }) => {
     const { note, setNote } = useNote();
     const [showReport, setShowReport] = useState<boolean>(false);
     const { patientRecords, setPatientRecords } = usePatientRecords();
@@ -82,11 +83,43 @@ const ExpandedNode: FC<ExpandedNodeProps> = memo(
       setShowReport(false);
     };
 
+    const onAdvance = (): void => {
+      const newPatientRecords = [...patientRecords];
+
+      const documentReference: DocumentReference = {
+        resourceType: 'DocumentReference',
+        status: 'current',
+        content: [
+          {
+            attachment: {
+              data: btoa(`${pathwayState.label} - Advance`),
+              contentType: 'text/plain'
+            }
+          }
+        ],
+        type: {
+          coding: [
+            {
+              system: 'http://loinc.org',
+              code: '34108-1',
+              display: 'Outpatient Note'
+            }
+          ]
+        },
+        indexed: ''
+      };
+
+      newPatientRecords.push(documentReference);
+      client?.create?.(documentReference);
+      setPatientRecords(newPatientRecords);
+    };
+
     return (
       <>
         <ExpandedNodeMemo
           isGuidance={isGuidance}
           isActionable={isActionable}
+          isCurrentNode={isCurrentNode}
           pathwayState={pathwayState}
           documentation={documentation}
           setComments={setComments}
@@ -104,6 +137,7 @@ const ExpandedNode: FC<ExpandedNodeProps> = memo(
             setShowReport(true);
           }}
           isAccepted={isAccepted}
+          onAdvance={onAdvance}
         />
         {showReport && (
           <ReportModal
@@ -343,11 +377,13 @@ interface ExpandedNodeMemoProps {
   pathwayState: GuidanceState;
   isGuidance: boolean;
   isActionable: boolean;
+  isCurrentNode: boolean;
   comments: string;
   setComments: (value: string) => void;
   onAccept: () => void;
   onDecline: () => void;
   isAccepted: boolean | null;
+  onAdvance: () => void;
 }
 const ExpandedNodeMemo: FC<ExpandedNodeMemoProps> = memo(
   ({
@@ -355,11 +391,13 @@ const ExpandedNodeMemo: FC<ExpandedNodeMemoProps> = memo(
     pathwayState,
     isGuidance,
     isActionable,
+    isCurrentNode,
     comments,
     setComments,
     onAccept,
     onDecline,
-    isAccepted
+    isAccepted,
+    onAdvance
   }) => {
     const guidance = isGuidance && renderGuidance(pathwayState, documentation, isAccepted);
     const branch =
@@ -374,6 +412,12 @@ const ExpandedNodeMemo: FC<ExpandedNodeMemoProps> = memo(
             {guidance || branch}
           </tbody>
         </table>
+        {/* Node is advanceable if it has been accepted or declined */}
+        {pathwayState.transitions.length > 0 && !isActionable && isGuidance && isCurrentNode && (
+          <button className={indexStyles.button} onClick={onAdvance}>
+            Advance
+          </button>
+        )}
         {isActionable && isGuidance && (
           <form className={styles.commentsForm}>
             <div>

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -17,6 +17,7 @@ import {
   createNoteContent
 } from 'utils/fhirUtils';
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
+import { Button } from '@material-ui/core';
 import { useNote } from 'components/NoteDataProvider';
 import {
   Resource,
@@ -397,9 +398,14 @@ const ExpandedNodeMemo: FC<ExpandedNodeMemoProps> = memo(
         </table>
         {/* Node is advanceable if it has been accepted or declined */}
         {pathwayState.transitions.length > 0 && !isActionable && isGuidance && isCurrentNode && (
-          <button className={`${indexStyles.button} ${styles.button}`} onClick={onAdvance}>
+          <Button
+            className={`${indexStyles.button} ${styles.button}`}
+            variant="contained"
+            color="primary"
+            onClick={onAdvance}
+          >
             Advance
-          </button>
+          </Button>
         )}
         {isActionable && isGuidance && (
           <form className={styles.commentsForm}>

--- a/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
+++ b/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
@@ -56,7 +56,11 @@ const testActionState: GuidanceState = {
     }
   ],
   cql: 'Chemotherapy',
-  transitions: []
+  transitions: [
+    {
+      transition: 'Test transition'
+    }
+  ]
 };
 
 const testMedicationRequestState: GuidanceState = {
@@ -92,6 +96,8 @@ describe('<ExpandedNode />', () => {
         isActionable={false}
         isGuidance={true}
         documentation={undefined}
+        isAccepted={null}
+        isCurrentNode={true}
       />
     );
 
@@ -117,6 +123,8 @@ describe('<ExpandedNode />', () => {
         isActionable={false}
         isGuidance={true}
         documentation={undefined}
+        isAccepted={null}
+        isCurrentNode={true}
       />
     );
 
@@ -138,6 +146,7 @@ describe('<ExpandedNode />', () => {
         isGuidance={true}
         documentation={testDoc}
         isAccepted={true}
+        isCurrentNode={true}
       />
     );
 
@@ -151,5 +160,21 @@ describe('<ExpandedNode />', () => {
     expect(getByText('Accept')).toBeVisible();
     expect(getByText('Decline')).toBeVisible();
     expect(getByText('Use Default Text')).toBeVisible();
+  });
+
+  it('renders advance button', () => {
+    const { getByText } = render(
+      <ExpandedNode
+        pathwayState={testActionState}
+        isActionable={false}
+        isGuidance={true}
+        documentation={testDoc}
+        isAccepted={null}
+        isCurrentNode={true}
+      />
+    );
+
+    // Advance button should be displayed on node that is non-actionable, guidance, and current
+    expect(getByText('Advance')).toBeVisible();
   });
 });

--- a/src/components/MissingDataPopup/MissingDataPopup.tsx
+++ b/src/components/MissingDataPopup/MissingDataPopup.tsx
@@ -7,7 +7,7 @@ import { faEdit } from '@fortawesome/free-solid-svg-icons';
 import { usePatient } from 'components/PatientProvider';
 import { usePatientRecords } from 'components/PatientRecordsProvider';
 import { useFHIRClient } from 'components/FHIRClient';
-import { createDocumentReference, createNoteContent } from 'utils/fhirUtils';
+import { createActionDocumentReference, createNoteContent } from 'utils/fhirUtils';
 import { useNote } from 'components/NoteDataProvider';
 interface MissingDataPopup {
   values: string[];
@@ -81,7 +81,7 @@ const PopupContent: FC<PopupContentProps> = ({ values, setOpen }) => {
               // Create DocumentReference with selected value and add to patient record
               if (note) {
                 const noteString = createNoteContent(note, patientRecords, 'completed', selected);
-                const documentReference = createDocumentReference(noteString, selected, patient);
+                const documentReference = createActionDocumentReference(noteString, selected, patient);
                 setPatientRecords([...patientRecords, documentReference]);
                 client?.create?.(documentReference);
               }

--- a/src/components/MissingDataPopup/MissingDataPopup.tsx
+++ b/src/components/MissingDataPopup/MissingDataPopup.tsx
@@ -81,7 +81,11 @@ const PopupContent: FC<PopupContentProps> = ({ values, setOpen }) => {
               // Create DocumentReference with selected value and add to patient record
               if (note) {
                 const noteString = createNoteContent(note, patientRecords, 'completed', selected);
-                const documentReference = createActionDocumentReference(noteString, selected, patient);
+                const documentReference = createActionDocumentReference(
+                  noteString,
+                  selected,
+                  patient
+                );
                 setPatientRecords([...patientRecords, documentReference]);
                 client?.create?.(documentReference);
               }

--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -121,6 +121,7 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
                 isGuidance={isGuidance}
                 documentation={documentation}
                 isAccepted={isAccepted}
+                isCurrentNode={isCurrentNode}
               />
             </div>
           )}

--- a/src/engine/output-results.ts
+++ b/src/engine/output-results.ts
@@ -234,7 +234,7 @@ function shouldAdvance(currentState: State, resources: DomainResource[]): boolea
     const content = (r as DocumentReference).content[0].attachment.data;
     if (content) {
       const convertedContent = atob(content);
-      return convertedContent.includes(currentState.label) && convertedContent.includes('Advance');
+      return convertedContent === `${currentState.label} - Advance`;
     }
 
     return false;

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -74,11 +74,7 @@ export function getHumanName(person: HumanName[]): string {
   return name;
 }
 
-export function createDocumentReference(
-  data: string,
-  labelOrCondition: string,
-  patient: Patient
-): DocumentReference {
+export function createDocumentReference(data: string, patient: Patient): DocumentReference {
   return {
     resourceType: 'DocumentReference',
     id: v1(),
@@ -87,12 +83,6 @@ export function createDocumentReference(
     },
     status: 'current',
     subject: { reference: `Patient/${patient.id}` },
-    identifier: [
-      {
-        system: 'pathways.documentreference',
-        value: btoa(labelOrCondition)
-      }
-    ],
     content: [
       {
         attachment: {
@@ -112,6 +102,23 @@ export function createDocumentReference(
       ]
     },
     indexed: ''
+  };
+}
+
+export function createActionDocumentReference(
+  data: string,
+  labelOrCondition: string,
+  patient: Patient
+): DocumentReference {
+  const documentReference = createDocumentReference(data, patient);
+  return {
+    ...documentReference,
+    identifier: [
+      {
+        system: 'pathways.documentreference',
+        value: btoa(labelOrCondition)
+      }
+    ]
   };
 }
 


### PR DESCRIPTION
Added advance button to force move to next state when a node has been accepted/declined.

![image](https://user-images.githubusercontent.com/6588796/83638401-13cb4000-a577-11ea-95d4-2cd53fb855ca.png)

The advance button appears when the node is current, non-actionable, guidance, and contains transitions.

When button is clicked, a `DocumentReference` is added to the list of patient resources. The content in the `DocumentReference` just has a string that contains the state label and the word Advance, which is how I am searching for the `DocumentReference` in the engine. Did we want anything else in the content or the resource?