### PR TITLE
alter behavior when node is guidance node

### DIFF
--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -162,18 +162,18 @@ const StatusField: FC<StatusFieldProps> = ({ documentation, isAccepted }) => {
   const rawDate = documentation.resource?.meta?.lastUpdated;
   if (rawDate) {
     const date = new Date(rawDate).toLocaleString('en-us');
-    let declinedText = '';
+    let titleText = '';
     if (isAccepted) {
-      declinedText = status.charAt(0).toUpperCase() + status.slice(1);
+      titleText = status.charAt(0).toUpperCase() + status.slice(1);
     } else if (isAccepted === null) {
-      declinedText = 'Status';
+      titleText = 'Status';
     } else {
-      declinedText = 'Declined';
+      titleText = 'Declined';
     }
     return (
       <ExpandedNodeField
         key="Status"
-        title={isAccepted ? status.charAt(0).toUpperCase() + status.slice(1) : declinedText}
+        title={titleText}
         description={isAccepted ? date : date.concat(' by Dr. Example')}
       />
     );

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -152,10 +152,9 @@ const ExpandedNodeField: FC<ExpandedNodeFieldProps> = ({ title, description }) =
 type StatusFieldProps = {
   documentation: DocumentationResource | undefined;
   isAccepted: boolean | null;
-  isGuidance: boolean;
 };
 
-const StatusField: FC<StatusFieldProps> = ({ documentation, isAccepted, isGuidance }) => {
+const StatusField: FC<StatusFieldProps> = ({ documentation, isAccepted }) => {
   if (!documentation?.resource) {
     return null;
   }
@@ -163,7 +162,14 @@ const StatusField: FC<StatusFieldProps> = ({ documentation, isAccepted, isGuidan
   const rawDate = documentation.resource?.meta?.lastUpdated;
   if (rawDate) {
     const date = new Date(rawDate).toLocaleString('en-us');
-    const declinedText = isGuidance ? 'Declined' : 'Status';
+    let declinedText = '';
+    if (isAccepted) {
+      declinedText = status.charAt(0).toUpperCase() + status.slice(1);
+    } else if (isAccepted === null) {
+      declinedText = 'Status';
+    } else {
+      declinedText = 'Declined';
+    }
     return (
       <ExpandedNodeField
         key="Status"
@@ -407,11 +413,7 @@ const ExpandedNodeMemo: FC<ExpandedNodeMemoProps> = memo(
       <div className={indexStyles.expandedNode}>
         <table className={styles.infoTable}>
           <tbody>
-            <StatusField
-              documentation={documentation}
-              isAccepted={isAccepted}
-              isGuidance={isGuidance}
-            />
+            <StatusField documentation={documentation} isAccepted={isAccepted} />
             {guidance || branch}
             {!isActionable && notes && /\S/.test(notes) && (
               <ExpandedNodeField key="Comments" title="Comments" description={notes} />

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -152,9 +152,10 @@ const ExpandedNodeField: FC<ExpandedNodeFieldProps> = ({ title, description }) =
 type StatusFieldProps = {
   documentation: DocumentationResource | undefined;
   isAccepted: boolean | null;
+  isGuidance: boolean;
 };
 
-const StatusField: FC<StatusFieldProps> = ({ documentation, isAccepted }) => {
+const StatusField: FC<StatusFieldProps> = ({ documentation, isAccepted, isGuidance }) => {
   if (!documentation?.resource) {
     return null;
   }
@@ -162,10 +163,11 @@ const StatusField: FC<StatusFieldProps> = ({ documentation, isAccepted }) => {
   const rawDate = documentation.resource?.meta?.lastUpdated;
   if (rawDate) {
     const date = new Date(rawDate).toLocaleString('en-us');
+    const declinedText = isGuidance ? 'Declined' : 'Status';
     return (
       <ExpandedNodeField
         key="Status"
-        title={isAccepted ? status.charAt(0).toUpperCase() + status.slice(1) : 'Declined'}
+        title={isAccepted ? status.charAt(0).toUpperCase() + status.slice(1) : declinedText}
         description={isAccepted ? date : date.concat(' by Dr. Example')}
       />
     );
@@ -405,7 +407,11 @@ const ExpandedNodeMemo: FC<ExpandedNodeMemoProps> = memo(
       <div className={indexStyles.expandedNode}>
         <table className={styles.infoTable}>
           <tbody>
-            <StatusField documentation={documentation} isAccepted={isAccepted} />
+            <StatusField
+              documentation={documentation}
+              isAccepted={isAccepted}
+              isGuidance={isGuidance}
+            />
             {guidance || branch}
             {!isActionable && notes && /\S/.test(notes) && (
               <ExpandedNodeField key="Comments" title="Comments" description={notes} />


### PR DESCRIPTION
I'm not sure if this is the intended way we want to fix this bug, since it doesn't really change the fact that it's still treating branch nodes having missing data filled as being "declined", but it does alter the behavior branch nodes to show "Status" instead of "declined".  I think the main issue was that "isAccepted" is null for branch nodes, so when it went to fill out the "status" field it just defaulted to using "declined" instead, since null would be treated as false.