### PR TITLE
Standardize nomenclature

### DIFF
--- a/public/static/pathways/her2_pathway.json
+++ b/public/static/pathways/her2_pathway.json
@@ -2,7 +2,7 @@
   "name": "Breast Cancer: Early Stage HER2+ (Draft)",
   "description": "Pathway for the Early Stage HER2+ Initial Medical Consult Breast Cancer Pathway. This is a draft pathway.",
   "library": "mCODE_Library.cql",
-  "criteria": [
+  "precondition": [
     {
       "elementName": "Condition",
       "expected": "Breast Cancer",
@@ -1292,7 +1292,7 @@
           }
        }
     },
-    "criteria":{
+    "precondition":{
        "library" : {
           "identifier" : {
              "id" : "mCODEResources",

--- a/public/static/pathways/her2_pathway.json
+++ b/public/static/pathways/her2_pathway.json
@@ -14,7 +14,7 @@
       "cql": "[Observation: \"HER2 [Presence] in Breast cancer specimen by Immune stain\"] Her2 return Tuple{ value: Her2.value.text.value, match: Her2.value.text.value ~ 'Positive' } "
     }
   ],
-  "states": {
+  "nodes": {
     "Start": {
       "label": "Start",
       "transitions": [

--- a/public/static/pathways/her2_pathway.json
+++ b/public/static/pathways/her2_pathway.json
@@ -2,7 +2,7 @@
   "name": "Breast Cancer: Early Stage HER2+ (Draft)",
   "description": "Pathway for the Early Stage HER2+ Initial Medical Consult Breast Cancer Pathway. This is a draft pathway.",
   "library": "mCODE_Library.cql",
-  "precondition": [
+  "preconditions": [
     {
       "elementName": "Condition",
       "expected": "Breast Cancer",
@@ -1292,7 +1292,7 @@
           }
        }
     },
-    "precondition":{
+    "preconditions":{
        "library" : {
           "identifier" : {
              "id" : "mCODEResources",

--- a/public/static/pathways/neoadjuvant_pathway.json
+++ b/public/static/pathways/neoadjuvant_pathway.json
@@ -14,7 +14,7 @@
         "cql": "[Observation: \"HER2 [Presence] in Breast cancer specimen by Immune stain\"] Her2 return Tuple{ value: Her2.value.text.value, match: Her2.value.text.value ~ 'Positive' } "
       }
     ],
-    "states": {
+    "nodes": {
       "Start": {
         "label": "Start",
         "transitions": [

--- a/public/static/pathways/neoadjuvant_pathway.json
+++ b/public/static/pathways/neoadjuvant_pathway.json
@@ -2,7 +2,7 @@
     "name": "Breast Cancer: Neoadjuvant Chemotherapy with Surgery ",
     "description": "Pathway for the Early Stage HER2+ Breast Cancer Pathway for neoadjuvant chemotherapy with surgery.",
     "library": "mCODE_Library.cql",
-    "criteria": [
+    "precondition": [
       {
         "elementName": "Condition",
         "expected": "Breast Cancer",
@@ -1933,7 +1933,7 @@
             }
          }
       },
-      "criteria": {
+      "precondition": {
          "library" : {
             "identifier" : {
                "id" : "mCODEResources",

--- a/public/static/pathways/neoadjuvant_pathway.json
+++ b/public/static/pathways/neoadjuvant_pathway.json
@@ -2,7 +2,7 @@
     "name": "Breast Cancer: Neoadjuvant Chemotherapy with Surgery ",
     "description": "Pathway for the Early Stage HER2+ Breast Cancer Pathway for neoadjuvant chemotherapy with surgery.",
     "library": "mCODE_Library.cql",
-    "precondition": [
+    "preconditions": [
       {
         "elementName": "Condition",
         "expected": "Breast Cancer",
@@ -1933,7 +1933,7 @@
             }
          }
       },
-      "precondition": {
+      "preconditions": {
          "library" : {
             "identifier" : {
                "id" : "mCODEResources",

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactNode, ReactElement, useState, memo } from 'react';
-import { GuidanceNode, DocumentationResource, PathwayNode, Action } from 'pathways-model';
+import { ActionNode, DocumentationResource, PathwayNode, Action } from 'pathways-model';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import MissingDataPopup from 'components/MissingDataPopup';
 import styles from './ExpandedNode.module.scss';
@@ -32,16 +32,16 @@ import {
 import { retrieveNote } from 'utils/fhirUtils';
 
 interface ExpandedNodeProps {
-  pathwayNode: GuidanceNode;
+  pathwayNode: ActionNode;
   isActionable: boolean;
   isCurrentNode: boolean;
-  isGuidance: boolean;
+  isAction: boolean;
   documentation: DocumentationResource | undefined;
   isAccepted: boolean | null;
 }
 
 const ExpandedNode: FC<ExpandedNodeProps> = memo(
-  ({ pathwayNode, isActionable, isCurrentNode, isGuidance, documentation, isAccepted }) => {
+  ({ pathwayNode, isActionable, isCurrentNode, isAction, documentation, isAccepted }) => {
     const { note, setNote } = useNote();
     const [showReport, setShowReport] = useState<boolean>(false);
     const { patientRecords, setPatientRecords } = usePatientRecords();
@@ -102,7 +102,7 @@ const ExpandedNode: FC<ExpandedNodeProps> = memo(
     return (
       <>
         <ExpandedNodeMemo
-          isGuidance={isGuidance}
+          isAction={isAction}
           isActionable={isActionable}
           isCurrentNode={isCurrentNode}
           pathwayNode={pathwayNode}
@@ -286,8 +286,8 @@ function isMedicationRequest(
 ): request is MedicationRequest {
   return (request as MedicationRequest).medicationCodeableConcept !== undefined;
 }
-function renderGuidance(
-  pathwayNode: GuidanceNode,
+function renderAction(
+  pathwayNode: ActionNode,
   documentation: DocumentationResource | undefined,
   isAccepted: boolean | null
 ): ReactElement[] {
@@ -367,8 +367,8 @@ function renderGuidance(
 
 interface ExpandedNodeMemoProps {
   documentation: DocumentationResource | undefined;
-  pathwayNode: GuidanceNode;
-  isGuidance: boolean;
+  pathwayNode: ActionNode;
+  isAction: boolean;
   isActionable: boolean;
   isCurrentNode: boolean;
   comments: string;
@@ -382,7 +382,7 @@ const ExpandedNodeMemo: FC<ExpandedNodeMemoProps> = memo(
   ({
     documentation,
     pathwayNode,
-    isGuidance,
+    isAction,
     isActionable,
     isCurrentNode,
     comments,
@@ -393,7 +393,7 @@ const ExpandedNodeMemo: FC<ExpandedNodeMemoProps> = memo(
     onAdvance
   }) => {
     const { patientRecords } = usePatientRecords();
-    const guidance = isGuidance && renderGuidance(pathwayNode, documentation, isAccepted);
+    const action = isAction && renderAction(pathwayNode, documentation, isAccepted);
     const branch =
       isBranchNode(pathwayNode) && renderBranch(documentation, pathwayNode, isAccepted);
     const defaultText =
@@ -414,14 +414,14 @@ const ExpandedNodeMemo: FC<ExpandedNodeMemoProps> = memo(
         <table className={styles.infoTable}>
           <tbody>
             <StatusField documentation={documentation} isAccepted={isAccepted} />
-            {guidance || branch}
+            {action || branch}
             {!isActionable && notes && /\S/.test(notes) && (
               <ExpandedNodeField key="Comments" title="Comments" description={notes} />
             )}
           </tbody>
         </table>
         {/* Node is advanceable if it has been accepted or declined */}
-        {pathwayNode.transitions.length > 0 && !isActionable && isGuidance && isCurrentNode && (
+        {pathwayNode.transitions.length > 0 && !isActionable && isAction && isCurrentNode && (
           <Button
             className={`${indexStyles.button} ${styles.button}`}
             variant="contained"
@@ -431,7 +431,7 @@ const ExpandedNodeMemo: FC<ExpandedNodeMemoProps> = memo(
             Advance
           </Button>
         )}
-        {isActionable && isGuidance && (
+        {isActionable && isAction && (
           <form className={styles.commentsForm}>
             <div>
               <label>Comments:</label>

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -32,7 +32,7 @@ import {
 import { retrieveNote } from 'utils/fhirUtils';
 
 interface ExpandedNodeProps {
-  pathwayNode: ActionNode;
+  actionNode: ActionNode;
   isActionable: boolean;
   isCurrentNode: boolean;
   isAction: boolean;
@@ -41,7 +41,7 @@ interface ExpandedNodeProps {
 }
 
 const ExpandedNode: FC<ExpandedNodeProps> = memo(
-  ({ pathwayNode, isActionable, isCurrentNode, isAction, documentation, isAccepted }) => {
+  ({ actionNode, isActionable, isCurrentNode, isAction, documentation, isAccepted }) => {
     const { note, setNote } = useNote();
     const [showReport, setShowReport] = useState<boolean>(false);
     const { patientRecords, setPatientRecords } = usePatientRecords();
@@ -52,7 +52,7 @@ const ExpandedNode: FC<ExpandedNodeProps> = memo(
       });
     };
     const patient = usePatient().patient as fhir.Patient;
-    if (note) note.node = pathwayNode.label;
+    if (note) note.node = actionNode.label;
 
     const onConfirm = (action?: Action[]): void => {
       const newPatientRecords = [...patientRecords];
@@ -64,11 +64,11 @@ const ExpandedNode: FC<ExpandedNodeProps> = memo(
           patientRecords,
           note.status,
           note?.notes ?? '',
-          pathwayNode
+          actionNode
         );
         const documentReference = createActionDocumentReference(
           noteString,
-          pathwayNode.label,
+          actionNode.label,
           patient
         );
 
@@ -92,7 +92,7 @@ const ExpandedNode: FC<ExpandedNodeProps> = memo(
     };
 
     const onAdvance = (): void => {
-      const content = `${pathwayNode.label} - Advance`;
+      const content = `${actionNode.label} - Advance`;
       const documentReference = createDocumentReference(content, patient);
 
       client?.create?.(documentReference);
@@ -105,7 +105,7 @@ const ExpandedNode: FC<ExpandedNodeProps> = memo(
           isAction={isAction}
           isActionable={isActionable}
           isCurrentNode={isCurrentNode}
-          pathwayNode={pathwayNode}
+          actionNode={actionNode}
           documentation={documentation}
           setComments={setComments}
           comments={note?.notes ?? ''}
@@ -126,7 +126,7 @@ const ExpandedNode: FC<ExpandedNodeProps> = memo(
         />
         {showReport && (
           <ReportModal
-            onConfirm={(): void => onConfirm(pathwayNode.action)}
+            onConfirm={(): void => onConfirm(actionNode.action)}
             onDecline={(): void => setShowReport(false)}
           />
         )}
@@ -287,11 +287,11 @@ function isMedicationRequest(
   return (request as MedicationRequest).medicationCodeableConcept !== undefined;
 }
 function renderAction(
-  pathwayNode: ActionNode,
+  actionNode: ActionNode,
   documentation: DocumentationResource | undefined,
   isAccepted: boolean | null
 ): ReactElement[] {
-  const resource = pathwayNode.action[0].resource;
+  const resource = actionNode.action[0].resource;
   const coding = isMedicationRequest(resource)
     ? resource?.medicationCodeableConcept?.coding
     : resource?.code?.coding;
@@ -300,7 +300,7 @@ function renderAction(
     <ExpandedNodeField
       key="Description"
       title="Description"
-      description={pathwayNode.action[0].description}
+      description={actionNode.action[0].description}
     />,
     <ExpandedNodeField key="Type" title="Type" description={resource.resourceType} />
   ];
@@ -367,7 +367,7 @@ function renderAction(
 
 interface ExpandedNodeMemoProps {
   documentation: DocumentationResource | undefined;
-  pathwayNode: ActionNode;
+  actionNode: ActionNode;
   isAction: boolean;
   isActionable: boolean;
   isCurrentNode: boolean;
@@ -381,7 +381,7 @@ interface ExpandedNodeMemoProps {
 const ExpandedNodeMemo: FC<ExpandedNodeMemoProps> = memo(
   ({
     documentation,
-    pathwayNode,
+    actionNode,
     isAction,
     isActionable,
     isCurrentNode,
@@ -393,14 +393,13 @@ const ExpandedNodeMemo: FC<ExpandedNodeMemoProps> = memo(
     onAdvance
   }) => {
     const { patientRecords } = usePatientRecords();
-    const action = isAction && renderAction(pathwayNode, documentation, isAccepted);
-    const branch =
-      isBranchNode(pathwayNode) && renderBranch(documentation, pathwayNode, isAccepted);
+    const action = isAction && renderAction(actionNode, documentation, isAccepted);
+    const branch = isBranchNode(actionNode) && renderBranch(documentation, actionNode, isAccepted);
     const defaultText =
       'The patient and I discussed the treatment plan, risks, benefits and alternatives.  The patient expressed understanding and wants to proceed.';
 
     let notes;
-    const documentReference = retrieveNote(pathwayNode.label, patientRecords);
+    const documentReference = retrieveNote(actionNode.label, patientRecords);
     if (documentReference) {
       const content = documentReference.content[0].attachment?.data;
       if (content) {
@@ -421,7 +420,7 @@ const ExpandedNodeMemo: FC<ExpandedNodeMemoProps> = memo(
           </tbody>
         </table>
         {/* Node is advanceable if it has been accepted or declined */}
-        {pathwayNode.transitions.length > 0 && !isActionable && isAction && isCurrentNode && (
+        {actionNode.transitions.length > 0 && !isActionable && isAction && isCurrentNode && (
           <Button
             className={`${indexStyles.button} ${styles.button}`}
             variant="contained"

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactNode, ReactElement, useState, memo } from 'react';
-import { PathwayActionNode, DocumentationResource, PathwayNode, Action } from 'pathways-model';
+import { ActionNode, DocumentationResource, PathwayNode, Action } from 'pathways-model';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import MissingDataPopup from 'components/MissingDataPopup';
 import styles from './ExpandedNode.module.scss';
@@ -32,7 +32,7 @@ import {
 import { retrieveNote } from 'utils/fhirUtils';
 
 interface ExpandedNodeProps {
-  actionNode: PathwayActionNode;
+  actionNode: ActionNode;
   isActionable: boolean;
   isCurrentNode: boolean;
   isAction: boolean;
@@ -287,7 +287,7 @@ function isMedicationRequest(
   return (request as MedicationRequest).medicationCodeableConcept !== undefined;
 }
 function renderAction(
-  actionNode: PathwayActionNode,
+  actionNode: ActionNode,
   documentation: DocumentationResource | undefined,
   isAccepted: boolean | null
 ): ReactElement[] {
@@ -367,7 +367,7 @@ function renderAction(
 
 interface ExpandedNodeMemoProps {
   documentation: DocumentationResource | undefined;
-  actionNode: PathwayActionNode;
+  actionNode: ActionNode;
   isAction: boolean;
   isActionable: boolean;
   isCurrentNode: boolean;

--- a/src/components/ExpandedNode/ExpandedNode.tsx
+++ b/src/components/ExpandedNode/ExpandedNode.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactNode, ReactElement, useState, memo } from 'react';
-import { ActionNode, DocumentationResource, PathwayNode, Action } from 'pathways-model';
+import { PathwayActionNode, DocumentationResource, PathwayNode, Action } from 'pathways-model';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import MissingDataPopup from 'components/MissingDataPopup';
 import styles from './ExpandedNode.module.scss';
@@ -32,7 +32,7 @@ import {
 import { retrieveNote } from 'utils/fhirUtils';
 
 interface ExpandedNodeProps {
-  actionNode: ActionNode;
+  actionNode: PathwayActionNode;
   isActionable: boolean;
   isCurrentNode: boolean;
   isAction: boolean;
@@ -287,7 +287,7 @@ function isMedicationRequest(
   return (request as MedicationRequest).medicationCodeableConcept !== undefined;
 }
 function renderAction(
-  actionNode: ActionNode,
+  actionNode: PathwayActionNode,
   documentation: DocumentationResource | undefined,
   isAccepted: boolean | null
 ): ReactElement[] {
@@ -367,7 +367,7 @@ function renderAction(
 
 interface ExpandedNodeMemoProps {
   documentation: DocumentationResource | undefined;
-  actionNode: ActionNode;
+  actionNode: PathwayActionNode;
   isAction: boolean;
   isActionable: boolean;
   isCurrentNode: boolean;

--- a/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
+++ b/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
@@ -92,7 +92,7 @@ describe('<ExpandedNode />', () => {
   it('renders a ExpandedNode for action node', () => {
     const { getByText, queryByRole, queryByText } = render(
       <ExpandedNode
-        pathwayNode={testActionState}
+        actionNode={testActionState}
         isActionable={false}
         isAction={true}
         documentation={undefined}
@@ -119,7 +119,7 @@ describe('<ExpandedNode />', () => {
   it('renders a ExpandedNode for a medication request state', () => {
     const { getByText } = render(
       <ExpandedNode
-        pathwayNode={testMedicationRequestState}
+        actionNode={testMedicationRequestState}
         isActionable={false}
         isAction={true}
         documentation={undefined}
@@ -141,7 +141,7 @@ describe('<ExpandedNode />', () => {
   it('renders an active ExpandedNode', () => {
     const { getByText, getByRole } = render(
       <ExpandedNode
-        pathwayNode={testActionState}
+        actionNode={testActionState}
         isActionable={true}
         isAction={true}
         documentation={testDoc}
@@ -165,7 +165,7 @@ describe('<ExpandedNode />', () => {
   it('renders advance button', () => {
     const { getByText } = render(
       <ExpandedNode
-        pathwayNode={testActionState}
+        actionNode={testActionState}
         isActionable={false}
         isAction={true}
         documentation={testDoc}

--- a/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
+++ b/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import ExpandedNode from 'components/ExpandedNode';
 import {
-  GuidanceNode,
+  ActionNode,
   BasicActionResource,
   BasicMedicationRequestResource,
   DocumentationResource
@@ -34,7 +34,7 @@ const testDoc: DocumentationResource = {
     ]
   }
 };
-const testActionState: GuidanceNode = {
+const testActionState: ActionNode = {
   label: 'Chemotherapy',
   action: [
     {
@@ -63,7 +63,7 @@ const testActionState: GuidanceNode = {
   ]
 };
 
-const testMedicationRequestState: GuidanceNode = {
+const testMedicationRequestState: ActionNode = {
   label: 'ChemoMedication Request',
   action: [
     {
@@ -94,7 +94,7 @@ describe('<ExpandedNode />', () => {
       <ExpandedNode
         pathwayNode={testActionState}
         isActionable={false}
-        isGuidance={true}
+        isAction={true}
         documentation={undefined}
         isAccepted={null}
         isCurrentNode={true}
@@ -121,7 +121,7 @@ describe('<ExpandedNode />', () => {
       <ExpandedNode
         pathwayNode={testMedicationRequestState}
         isActionable={false}
-        isGuidance={true}
+        isAction={true}
         documentation={undefined}
         isAccepted={null}
         isCurrentNode={true}
@@ -143,7 +143,7 @@ describe('<ExpandedNode />', () => {
       <ExpandedNode
         pathwayNode={testActionState}
         isActionable={true}
-        isGuidance={true}
+        isAction={true}
         documentation={testDoc}
         isAccepted={true}
         isCurrentNode={true}
@@ -167,14 +167,14 @@ describe('<ExpandedNode />', () => {
       <ExpandedNode
         pathwayNode={testActionState}
         isActionable={false}
-        isGuidance={true}
+        isAction={true}
         documentation={testDoc}
         isAccepted={null}
         isCurrentNode={true}
       />
     );
 
-    // Advance button should be displayed on node that is non-actionable, guidance, and current
+    // Advance button should be displayed on node that is non-actionable, action, and current
     expect(getByText('Advance')).toBeVisible();
   });
 });

--- a/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
+++ b/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
@@ -34,7 +34,7 @@ const testDoc: DocumentationResource = {
     ]
   }
 };
-const testActionState: ActionNode = {
+const testActionNode: ActionNode = {
   label: 'Chemotherapy',
   action: [
     {
@@ -63,7 +63,7 @@ const testActionState: ActionNode = {
   ]
 };
 
-const testMedicationRequestState: ActionNode = {
+const testMedicationRequestNode: ActionNode = {
   label: 'ChemoMedication Request',
   action: [
     {
@@ -92,7 +92,7 @@ describe('<ExpandedNode />', () => {
   it('renders a ExpandedNode for action node', () => {
     const { getByText, queryByRole, queryByText } = render(
       <ExpandedNode
-        actionNode={testActionState}
+        actionNode={testActionNode}
         isActionable={false}
         isAction={true}
         documentation={undefined}
@@ -101,9 +101,9 @@ describe('<ExpandedNode />', () => {
       />
     );
 
-    const resource = testActionState.action[0].resource as BasicActionResource;
+    const resource = testActionNode.action[0].resource as BasicActionResource;
 
-    expect(getByText(testActionState.action[0].description)).toBeVisible();
+    expect(getByText(testActionNode.action[0].description)).toBeVisible();
     expect(getByText(resource.resourceType)).toBeVisible();
     expect(getByText(resource.code.coding[0].system)).toBeVisible();
     expect(getByText(resource.code.coding[0].code)).toBeVisible();
@@ -116,10 +116,10 @@ describe('<ExpandedNode />', () => {
     expect(queryByText('Use Default Text')).toBeNull();
   });
 
-  it('renders a ExpandedNode for a medication request state', () => {
+  it('renders a ExpandedNode for a medication request node', () => {
     const { getByText } = render(
       <ExpandedNode
-        actionNode={testMedicationRequestState}
+        actionNode={testMedicationRequestNode}
         isActionable={false}
         isAction={true}
         documentation={undefined}
@@ -128,10 +128,9 @@ describe('<ExpandedNode />', () => {
       />
     );
 
-    const resource = testMedicationRequestState.action[0]
-      .resource as BasicMedicationRequestResource;
+    const resource = testMedicationRequestNode.action[0].resource as BasicMedicationRequestResource;
 
-    expect(getByText(testMedicationRequestState.action[0].description)).toBeVisible();
+    expect(getByText(testMedicationRequestNode.action[0].description)).toBeVisible();
     expect(getByText(resource.resourceType)).toBeVisible();
     expect(getByText(resource.medicationCodeableConcept.coding[0].system)).toBeVisible();
     expect(getByText(resource.medicationCodeableConcept.coding[0].code)).toBeVisible();
@@ -141,7 +140,7 @@ describe('<ExpandedNode />', () => {
   it('renders an active ExpandedNode', () => {
     const { getByText, getByRole } = render(
       <ExpandedNode
-        actionNode={testActionState}
+        actionNode={testActionNode}
         isActionable={true}
         isAction={true}
         documentation={testDoc}
@@ -165,7 +164,7 @@ describe('<ExpandedNode />', () => {
   it('renders advance button', () => {
     const { getByText } = render(
       <ExpandedNode
-        actionNode={testActionState}
+        actionNode={testActionNode}
         isActionable={false}
         isAction={true}
         documentation={testDoc}

--- a/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
+++ b/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import ExpandedNode from 'components/ExpandedNode';
 import {
-  PathwayActionNode,
+  ActionNode,
   BasicActionResource,
   BasicMedicationRequestResource,
   DocumentationResource
@@ -34,7 +34,7 @@ const testDoc: DocumentationResource = {
     ]
   }
 };
-const testActionState: PathwayActionNode = {
+const testActionState: ActionNode = {
   label: 'Chemotherapy',
   action: [
     {
@@ -63,7 +63,7 @@ const testActionState: PathwayActionNode = {
   ]
 };
 
-const testMedicationRequestState: PathwayActionNode = {
+const testMedicationRequestState: ActionNode = {
   label: 'ChemoMedication Request',
   action: [
     {

--- a/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
+++ b/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import ExpandedNode from 'components/ExpandedNode';
 import {
-  ActionNode,
+  PathwayActionNode,
   BasicActionResource,
   BasicMedicationRequestResource,
   DocumentationResource
@@ -34,7 +34,7 @@ const testDoc: DocumentationResource = {
     ]
   }
 };
-const testActionState: ActionNode = {
+const testActionState: PathwayActionNode = {
   label: 'Chemotherapy',
   action: [
     {
@@ -63,7 +63,7 @@ const testActionState: ActionNode = {
   ]
 };
 
-const testMedicationRequestState: ActionNode = {
+const testMedicationRequestState: PathwayActionNode = {
   label: 'ChemoMedication Request',
   action: [
     {

--- a/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
+++ b/src/components/ExpandedNode/__tests__/ExpandedNode.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import ExpandedNode from 'components/ExpandedNode';
 import {
-  GuidanceState,
+  GuidanceNode,
   BasicActionResource,
   BasicMedicationRequestResource,
   DocumentationResource
@@ -13,7 +13,7 @@ const testDoc: DocumentationResource = {
   resourceType: 'Observation',
   id: '138629',
   status: 'final',
-  state: 'N-test',
+  node: 'N-test',
   resource: {
     resourceType: 'Observation',
     id: '138629',
@@ -34,7 +34,7 @@ const testDoc: DocumentationResource = {
     ]
   }
 };
-const testActionState: GuidanceState = {
+const testActionState: GuidanceNode = {
   label: 'Chemotherapy',
   action: [
     {
@@ -63,7 +63,7 @@ const testActionState: GuidanceState = {
   ]
 };
 
-const testMedicationRequestState: GuidanceState = {
+const testMedicationRequestState: GuidanceNode = {
   label: 'ChemoMedication Request',
   action: [
     {
@@ -89,10 +89,10 @@ const testMedicationRequestState: GuidanceState = {
 };
 
 describe('<ExpandedNode />', () => {
-  it('renders a ExpandedNode for action state', () => {
+  it('renders a ExpandedNode for action node', () => {
     const { getByText, queryByRole, queryByText } = render(
       <ExpandedNode
-        pathwayState={testActionState}
+        pathwayNode={testActionState}
         isActionable={false}
         isGuidance={true}
         documentation={undefined}
@@ -119,7 +119,7 @@ describe('<ExpandedNode />', () => {
   it('renders a ExpandedNode for a medication request state', () => {
     const { getByText } = render(
       <ExpandedNode
-        pathwayState={testMedicationRequestState}
+        pathwayNode={testMedicationRequestState}
         isActionable={false}
         isGuidance={true}
         documentation={undefined}
@@ -141,7 +141,7 @@ describe('<ExpandedNode />', () => {
   it('renders an active ExpandedNode', () => {
     const { getByText, getByRole } = render(
       <ExpandedNode
-        pathwayState={testActionState}
+        pathwayNode={testActionState}
         isActionable={true}
         isGuidance={true}
         documentation={testDoc}
@@ -165,7 +165,7 @@ describe('<ExpandedNode />', () => {
   it('renders advance button', () => {
     const { getByText } = render(
       <ExpandedNode
-        pathwayState={testActionState}
+        pathwayNode={testActionState}
         isActionable={false}
         isGuidance={true}
         documentation={testDoc}

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -133,7 +133,7 @@ const Graph: FC<GraphProps> = memo(
       });
     }
     const layoutKeys = Object.keys(layout).toString();
-    const initialExpandedState = useMemo(() => {
+    const initialExpandedNode = useMemo(() => {
       return layoutKeys.split(',').reduce((acc: { [key: string]: boolean }, curr: string) => {
         acc[curr] = false;
         return acc;
@@ -141,7 +141,7 @@ const Graph: FC<GraphProps> = memo(
     }, [layoutKeys]);
 
     const [expanded, _setExpanded] = useState<{ [key: string]: boolean | undefined }>(
-      initialExpandedState
+      initialExpandedNode
     );
 
     const setExpanded = useCallback((key: string, expand?: boolean): void => {

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -37,7 +37,7 @@ interface GraphProps {
 const getPath = (pathwayResults: PathwayResults): string[] => {
   return Object.values(pathwayResults.documentation)
     .filter(doc => doc.onPath)
-    .map(doc => doc.state);
+    .map(doc => doc.node);
 };
 
 const isEdgeOnPatientPath = (pathwayResults: PathwayResults, edge: Edge): boolean => {
@@ -45,7 +45,7 @@ const isEdgeOnPatientPath = (pathwayResults: PathwayResults, edge: Edge): boolea
   const startIndex = path.indexOf(edge.start);
   const endIndex = path.indexOf(edge.end);
   if (startIndex !== -1 && endIndex !== -1 && startIndex + 1 === endIndex) return true;
-  else if (startIndex === path.length - 1 && pathwayResults.currentStates.includes(edge.end))
+  else if (startIndex === path.length - 1 && pathwayResults.currentNodes.includes(edge.end))
     return true;
   else return false;
 };
@@ -178,7 +178,7 @@ const Graph: FC<GraphProps> = memo(
     // Expand all the current nodes by default if allowed
     useEffect(() => {
       if (evaluatedPathway?.pathwayResults) {
-        for (const currentNode of evaluatedPathway.pathwayResults.currentStates) {
+        for (const currentNode of evaluatedPathway.pathwayResults.currentNodes) {
           if (expandCurrentNode) {
             if (currentNode) setExpanded(currentNode, true);
           }
@@ -296,16 +296,16 @@ const GraphMemo: FC<GraphMemoProps> = memo(
                     ref={(node: HTMLDivElement): void => {
                       nodeRefs.current[nodeName] = node;
                     }}
-                    pathwayState={pathway.states[nodeName]}
+                    pathwayNode={pathway.nodes[nodeName]}
                     isOnPatientPath={
                       evaluatedPathway.pathwayResults
                         ? getPath(evaluatedPathway.pathwayResults).includes(nodeName) ||
-                          evaluatedPathway.pathwayResults.currentStates.includes(nodeName)
+                          evaluatedPathway.pathwayResults.currentNodes.includes(nodeName)
                         : false
                     }
                     isCurrentNode={
                       evaluatedPathway.pathwayResults
-                        ? evaluatedPathway.pathwayResults.currentStates.includes(nodeName)
+                        ? evaluatedPathway.pathwayResults.currentNodes.includes(nodeName)
                         : false
                     }
                     xCoordinate={nodeCoordinates[nodeName].x + parentWidth / 2}

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -283,34 +283,34 @@ const GraphMemo: FC<GraphMemoProps> = memo(
         }}
       >
         {nodeCoordinates !== undefined
-          ? Object.keys(nodeCoordinates).map(nodeName => {
-              const docResource = documentation[nodeName] as DocumentationResource;
+          ? Object.keys(nodeCoordinates).map(nodeKey => {
+              const docResource = documentation[nodeKey] as DocumentationResource;
               const onClickHandler = useCallback(() => {
-                return interactive ? setExpanded(nodeName) : undefined;
-              }, [nodeName]);
+                return interactive ? setExpanded(nodeKey) : undefined;
+              }, [nodeKey]);
               return (
-                <NoteDataProvider date={new Date(Date.now())} key={nodeName}>
+                <NoteDataProvider date={new Date(Date.now())} key={nodeKey}>
                   <Node
-                    key={nodeName}
+                    key={nodeKey}
                     documentation={docResource}
                     ref={(node: HTMLDivElement): void => {
-                      nodeRefs.current[nodeName] = node;
+                      nodeRefs.current[nodeKey] = node;
                     }}
-                    pathwayNode={pathway.nodes[nodeName]}
+                    pathwayNode={pathway.nodes[nodeKey]}
                     isOnPatientPath={
                       evaluatedPathway.pathwayResults
-                        ? getPath(evaluatedPathway.pathwayResults).includes(nodeName) ||
-                          evaluatedPathway.pathwayResults.currentNodes.includes(nodeName)
+                        ? getPath(evaluatedPathway.pathwayResults).includes(nodeKey) ||
+                          evaluatedPathway.pathwayResults.currentNodes.includes(nodeKey)
                         : false
                     }
                     isCurrentNode={
                       evaluatedPathway.pathwayResults
-                        ? evaluatedPathway.pathwayResults.currentNodes.includes(nodeName)
+                        ? evaluatedPathway.pathwayResults.currentNodes.includes(nodeKey)
                         : false
                     }
-                    xCoordinate={nodeCoordinates[nodeName].x + parentWidth / 2}
-                    yCoordinate={nodeCoordinates[nodeName].y}
-                    expanded={expanded[nodeName]}
+                    xCoordinate={nodeCoordinates[nodeKey].x + parentWidth / 2}
+                    yCoordinate={nodeCoordinates[nodeKey].y}
+                    expanded={expanded[nodeKey]}
                     onClickHandler={onClickHandler}
                   />
                 </NoteDataProvider>

--- a/src/components/Graph/__tests__/Graph.test.tsx
+++ b/src/components/Graph/__tests__/Graph.test.tsx
@@ -94,7 +94,7 @@ describe('<Graph />', () => {
     const evaluatedPathway = pathwayList[0];
     evaluatedPathway.pathwayResults = {
       patientId: 'test',
-      currentStates: ['Start'],
+      currentNodes: ['Start'],
       documentation: [],
       path: ['Start']
     };

--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -116,7 +116,7 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
           {expanded && (
             <div className={`${styles.expandedNode} ${expandedNodeClass}`}>
               <ExpandedNode
-                pathwayNode={pathwayNode as ActionNode}
+                actionNode={pathwayNode as ActionNode}
                 isActionable={isActionable}
                 isAction={isAction}
                 documentation={documentation}
@@ -140,9 +140,9 @@ const NodeIcon: FC<NodeIconProps> = ({ pathwayNode, isAction }) => {
   let icon: IconProp = faMicroscope;
   if (pathwayNode.label === 'Start') icon = faPlay;
   if (isAction) {
-    const actionPathwayNode = pathwayNode as ActionNode;
-    if (actionPathwayNode.action.length > 0) {
-      const resourceType = actionPathwayNode.action[0].resource.resourceType;
+    const actionNode = pathwayNode as ActionNode;
+    if (actionNode.action.length > 0) {
+      const resourceType = actionNode.action[0].resource.resourceType;
       if (resourceType === 'MedicationRequest') icon = faPrescriptionBottleAlt;
       else if (resourceType === 'ServiceRequest') icon = faSyringe;
       else if (resourceType === 'CarePlan') icon = faBookMedical;

--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -1,7 +1,7 @@
 import React, { FC, Ref, forwardRef, memo } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
-import { PathwayActionNode, PathwayNode, DocumentationResource } from 'pathways-model';
+import { ActionNode, PathwayNode, DocumentationResource } from 'pathways-model';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './Node.module.scss';
@@ -116,7 +116,7 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
           {expanded && (
             <div className={`${styles.expandedNode} ${expandedNodeClass}`}>
               <ExpandedNode
-                actionNode={pathwayNode as PathwayActionNode}
+                actionNode={pathwayNode as ActionNode}
                 isActionable={isActionable}
                 isAction={isAction}
                 documentation={documentation}
@@ -140,7 +140,7 @@ const NodeIcon: FC<NodeIconProps> = ({ pathwayNode, isAction }) => {
   let icon: IconProp = faMicroscope;
   if (pathwayNode.label === 'Start') icon = faPlay;
   if (isAction) {
-    const actionNode = pathwayNode as PathwayActionNode;
+    const actionNode = pathwayNode as ActionNode;
     if (actionNode.action.length > 0) {
       const resourceType = actionNode.action[0].resource.resourceType;
       if (resourceType === 'MedicationRequest') icon = faPrescriptionBottleAlt;

--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -1,7 +1,7 @@
 import React, { FC, Ref, forwardRef, memo } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
-import { ActionNode, PathwayNode, DocumentationResource } from 'pathways-model';
+import { PathwayActionNode, PathwayNode, DocumentationResource } from 'pathways-model';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './Node.module.scss';
@@ -116,7 +116,7 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
           {expanded && (
             <div className={`${styles.expandedNode} ${expandedNodeClass}`}>
               <ExpandedNode
-                actionNode={pathwayNode as ActionNode}
+                actionNode={pathwayNode as PathwayActionNode}
                 isActionable={isActionable}
                 isAction={isAction}
                 documentation={documentation}
@@ -140,7 +140,7 @@ const NodeIcon: FC<NodeIconProps> = ({ pathwayNode, isAction }) => {
   let icon: IconProp = faMicroscope;
   if (pathwayNode.label === 'Start') icon = faPlay;
   if (isAction) {
-    const actionNode = pathwayNode as ActionNode;
+    const actionNode = pathwayNode as PathwayActionNode;
     if (actionNode.action.length > 0) {
       const resourceType = actionNode.action[0].resource.resourceType;
       if (resourceType === 'MedicationRequest') icon = faPrescriptionBottleAlt;

--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -1,13 +1,13 @@
 import React, { FC, Ref, forwardRef, memo } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
-import { GuidanceNode, PathwayNode, DocumentationResource } from 'pathways-model';
+import { ActionNode, PathwayNode, DocumentationResource } from 'pathways-model';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './Node.module.scss';
 import nodeStyles from 'styles/index.module.scss';
 import ExpandedNode from 'components/ExpandedNode';
-import { isGuidanceNode } from 'utils/nodeUtils';
+import { isActionNode } from 'utils/nodeUtils';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import {
   faMicroscope,
@@ -80,12 +80,12 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
           : clsx(styles.childNotOnPatientPath, classes['child-not-on-patient-path']);
       }
 
-      const isGuidance = isGuidanceNode(pathwayNode);
+      const isAction = isActionNode(pathwayNode);
       // TODO: how do we determine whether a node has been accepted or declined?
       // for now:
-      // if it's a non-actionable guidance node on the path: accepted == has documentation
-      // if it's actionable, not guidance or not on the path: null
-      const wasActionTaken = isOnPatientPath && isGuidance && !isActionable;
+      // if it's a non-actionable action node on the path: accepted == has documentation
+      // if it's actionable, not action or not on the path: null
+      const wasActionTaken = isOnPatientPath && isAction && !isActionable;
       const isAccepted = wasActionTaken
         ? documentation?.resourceType !== 'DocumentReference'
         : null;
@@ -96,7 +96,7 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
       let status = null;
       if ('action' in pathwayNode) {
         if (isOnPatientPath) status = isAccepted;
-        else status = isGuidance && documentation ? true : null;
+        else status = isAction && documentation ? true : null;
       } else if (!isCurrentNode && documentation) {
         status = true;
       }
@@ -108,7 +108,7 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
             onClick={onClickHandler}
           >
             <div className={nodeStyles.iconAndLabel}>
-              <NodeIcon pathwayNode={pathwayNode} isGuidance={isGuidance} />
+              <NodeIcon pathwayNode={pathwayNode} isAction={isAction} />
               {label}
             </div>
             <StatusIcon status={status} />
@@ -116,9 +116,9 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
           {expanded && (
             <div className={`${styles.expandedNode} ${expandedNodeClass}`}>
               <ExpandedNode
-                pathwayNode={pathwayNode as GuidanceNode}
+                pathwayNode={pathwayNode as ActionNode}
                 isActionable={isActionable}
-                isGuidance={isGuidance}
+                isAction={isAction}
                 documentation={documentation}
                 isAccepted={isAccepted}
                 isCurrentNode={isCurrentNode}
@@ -133,16 +133,16 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
 
 interface NodeIconProps {
   pathwayNode: PathwayNode;
-  isGuidance: boolean;
+  isAction: boolean;
 }
 
-const NodeIcon: FC<NodeIconProps> = ({ pathwayNode, isGuidance }) => {
+const NodeIcon: FC<NodeIconProps> = ({ pathwayNode, isAction }) => {
   let icon: IconProp = faMicroscope;
   if (pathwayNode.label === 'Start') icon = faPlay;
-  if (isGuidance) {
-    const guidancePathwayNode = pathwayNode as GuidanceNode;
-    if (guidancePathwayNode.action.length > 0) {
-      const resourceType = guidancePathwayNode.action[0].resource.resourceType;
+  if (isAction) {
+    const actionPathwayNode = pathwayNode as ActionNode;
+    if (actionPathwayNode.action.length > 0) {
+      const resourceType = actionPathwayNode.action[0].resource.resourceType;
       if (resourceType === 'MedicationRequest') icon = faPrescriptionBottleAlt;
       else if (resourceType === 'ServiceRequest') icon = faSyringe;
       else if (resourceType === 'CarePlan') icon = faBookMedical;

--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -1,13 +1,13 @@
 import React, { FC, Ref, forwardRef, memo } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
-import { GuidanceState, State, DocumentationResource } from 'pathways-model';
+import { GuidanceNode, PathwayNode, DocumentationResource } from 'pathways-model';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './Node.module.scss';
 import nodeStyles from 'styles/index.module.scss';
 import ExpandedNode from 'components/ExpandedNode';
-import { isGuidanceState } from 'utils/nodeUtils';
+import { isGuidanceNode } from 'utils/nodeUtils';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import {
   faMicroscope,
@@ -33,7 +33,7 @@ const useStyles = makeStyles(
 );
 
 interface NodeProps {
-  pathwayState: State;
+  pathwayNode: PathwayNode;
   documentation: DocumentationResource | undefined;
   isOnPatientPath: boolean;
   isCurrentNode: boolean;
@@ -47,7 +47,7 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
   forwardRef<HTMLDivElement, NodeProps>(
     (
       {
-        pathwayState,
+        pathwayNode,
         documentation,
         isOnPatientPath,
         isCurrentNode,
@@ -58,7 +58,7 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
       },
       ref
     ) => {
-      const { label } = pathwayState;
+      const { label } = pathwayNode;
       const style = {
         top: yCoordinate,
         left: xCoordinate
@@ -80,10 +80,10 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
           : clsx(styles.childNotOnPatientPath, classes['child-not-on-patient-path']);
       }
 
-      const isGuidance = isGuidanceState(pathwayState);
+      const isGuidance = isGuidanceNode(pathwayNode);
       // TODO: how do we determine whether a node has been accepted or declined?
       // for now:
-      // if it's a non-actionable guidance state on the path: accepted == has documentation
+      // if it's a non-actionable guidance node on the path: accepted == has documentation
       // if it's actionable, not guidance or not on the path: null
       const wasActionTaken = isOnPatientPath && isGuidance && !isActionable;
       const isAccepted = wasActionTaken
@@ -94,7 +94,7 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
         if (expanded) expandedNodeClass = styles.childDeclined;
       }
       let status = null;
-      if ('action' in pathwayState) {
+      if ('action' in pathwayNode) {
         if (isOnPatientPath) status = isAccepted;
         else status = isGuidance && documentation ? true : null;
       } else if (!isCurrentNode && documentation) {
@@ -108,7 +108,7 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
             onClick={onClickHandler}
           >
             <div className={nodeStyles.iconAndLabel}>
-              <NodeIcon pathwayState={pathwayState} isGuidance={isGuidance} />
+              <NodeIcon pathwayNode={pathwayNode} isGuidance={isGuidance} />
               {label}
             </div>
             <StatusIcon status={status} />
@@ -116,7 +116,7 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
           {expanded && (
             <div className={`${styles.expandedNode} ${expandedNodeClass}`}>
               <ExpandedNode
-                pathwayState={pathwayState as GuidanceState}
+                pathwayNode={pathwayNode as GuidanceNode}
                 isActionable={isActionable}
                 isGuidance={isGuidance}
                 documentation={documentation}
@@ -132,17 +132,17 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
 );
 
 interface NodeIconProps {
-  pathwayState: State;
+  pathwayNode: PathwayNode;
   isGuidance: boolean;
 }
 
-const NodeIcon: FC<NodeIconProps> = ({ pathwayState, isGuidance }) => {
+const NodeIcon: FC<NodeIconProps> = ({ pathwayNode, isGuidance }) => {
   let icon: IconProp = faMicroscope;
-  if (pathwayState.label === 'Start') icon = faPlay;
+  if (pathwayNode.label === 'Start') icon = faPlay;
   if (isGuidance) {
-    const guidancePathwayState = pathwayState as GuidanceState;
-    if (guidancePathwayState.action.length > 0) {
-      const resourceType = guidancePathwayState.action[0].resource.resourceType;
+    const guidancePathwayNode = pathwayNode as GuidanceNode;
+    if (guidancePathwayNode.action.length > 0) {
+      const resourceType = guidancePathwayNode.action[0].resource.resourceType;
       if (resourceType === 'MedicationRequest') icon = faPrescriptionBottleAlt;
       else if (resourceType === 'ServiceRequest') icon = faSyringe;
       else if (resourceType === 'CarePlan') icon = faBookMedical;

--- a/src/components/Node/__tests__/Node.test.tsx
+++ b/src/components/Node/__tests__/Node.test.tsx
@@ -11,7 +11,7 @@ describe('<Node />', () => {
   it('renders a node with text, icon, and correct styles', () => {
     const { container, getByText, getByRole } = render(
       <Node
-        pathwayState={testState}
+        pathwayNode={testState}
         isOnPatientPath={true}
         isCurrentNode={false}
         xCoordinate={0}
@@ -30,7 +30,7 @@ describe('<Node />', () => {
   it('renders correct background-color when node is not on patient path', () => {
     const { container } = render(
       <Node
-        pathwayState={testState}
+        pathwayNode={testState}
         isOnPatientPath={false}
         isCurrentNode={false}
         xCoordinate={0}
@@ -44,7 +44,7 @@ describe('<Node />', () => {
   it('expands the additional children when clicked', () => {
     const { container } = render(
       <Node
-        pathwayState={testState}
+        pathwayNode={testState}
         isOnPatientPath={true}
         isCurrentNode={false}
         xCoordinate={0}

--- a/src/components/Node/__tests__/Node.test.tsx
+++ b/src/components/Node/__tests__/Node.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import Node from '../Node';
 
-const testState = {
+const testNode = {
   label: 'Start',
   transitions: []
 };
@@ -11,7 +11,7 @@ describe('<Node />', () => {
   it('renders a node with text, icon, and correct styles', () => {
     const { container, getByText, getByRole } = render(
       <Node
-        pathwayNode={testState}
+        pathwayNode={testNode}
         isOnPatientPath={true}
         isCurrentNode={false}
         xCoordinate={0}
@@ -19,7 +19,7 @@ describe('<Node />', () => {
       />
     );
 
-    expect(getByText(testState.label)).toBeVisible();
+    expect(getByText(testNode.label)).toBeVisible();
     expect(getByRole('img', { hidden: true })).toBeVisible();
 
     expect(container.firstChild).toHaveClass('onPatientPath');
@@ -30,7 +30,7 @@ describe('<Node />', () => {
   it('renders correct background-color when node is not on patient path', () => {
     const { container } = render(
       <Node
-        pathwayNode={testState}
+        pathwayNode={testNode}
         isOnPatientPath={false}
         isCurrentNode={false}
         xCoordinate={0}
@@ -44,7 +44,7 @@ describe('<Node />', () => {
   it('expands the additional children when clicked', () => {
     const { container } = render(
       <Node
-        pathwayNode={testState}
+        pathwayNode={testNode}
         isOnPatientPath={true}
         isCurrentNode={false}
         xCoordinate={0}

--- a/src/components/PathwaysList/__tests__/PathwaysList.test.tsx
+++ b/src/components/PathwaysList/__tests__/PathwaysList.test.tsx
@@ -9,10 +9,10 @@ import {
   RenderResult
 } from '@testing-library/react';
 import PathwaysList from 'components/PathwaysList';
-import { evaluatePathwayPrecondition, evaluatePatientOnPathway } from 'engine';
+import { evaluatePathwayPreconditions, evaluatePatientOnPathway } from 'engine';
 
 import { loadingService, loadedService, errorService } from 'testUtils/services';
-import { evaluatedPrecondition, evaluatedPathwayResults } from 'testUtils/MockedValues';
+import { evaluatedPreconditions, evaluatedPathwayResults } from 'testUtils/MockedValues';
 import { Pathway, EvaluatedPathway } from 'pathways-model';
 import MockedPatientRecordsProvider from 'testUtils/MockedPatientRecordsProvider';
 import MockedPatientProvider from 'testUtils/MockedPatientProvider';
@@ -57,10 +57,10 @@ describe('<PathwaysList />', () => {
   });
 
   it('renders list of pathways', async () => {
-    (evaluatePathwayPrecondition as jest.Mock)
-      .mockResolvedValueOnce(evaluatedPrecondition[0])
-      .mockResolvedValueOnce(evaluatedPrecondition[1])
-      .mockResolvedValueOnce(evaluatedPrecondition[2]);
+    (evaluatePathwayPreconditions as jest.Mock)
+      .mockResolvedValueOnce(evaluatedPreconditions[0])
+      .mockResolvedValueOnce(evaluatedPreconditions[1])
+      .mockResolvedValueOnce(evaluatedPreconditions[2]);
     const result = await renderComponent(
       <PathwaysList
         evaluatedPathways={pathwayList}
@@ -89,10 +89,10 @@ describe('<PathwaysList />', () => {
   it('responds to click events with pathway', async () => {
     // eslint-disable-next-line
     console.error = jest.fn(); // Prevents act warning
-    (evaluatePathwayPrecondition as jest.Mock)
-      .mockResolvedValueOnce(evaluatedPrecondition[0])
-      .mockResolvedValueOnce(evaluatedPrecondition[1])
-      .mockResolvedValueOnce(evaluatedPrecondition[2]);
+    (evaluatePathwayPreconditions as jest.Mock)
+      .mockResolvedValueOnce(evaluatedPreconditions[0])
+      .mockResolvedValueOnce(evaluatedPreconditions[1])
+      .mockResolvedValueOnce(evaluatedPreconditions[2]);
     (evaluatePatientOnPathway as jest.Mock).mockResolvedValue(evaluatedPathwayResults);
     let value = '';
     function setValue(text: string): void {

--- a/src/components/PathwaysList/__tests__/PathwaysList.test.tsx
+++ b/src/components/PathwaysList/__tests__/PathwaysList.test.tsx
@@ -9,10 +9,10 @@ import {
   RenderResult
 } from '@testing-library/react';
 import PathwaysList from 'components/PathwaysList';
-import { evaluatePathwayCriteria, evaluatePatientOnPathway } from 'engine';
+import { evaluatePathwayPrecondition, evaluatePatientOnPathway } from 'engine';
 
 import { loadingService, loadedService, errorService } from 'testUtils/services';
-import { evaluatedCriteria, evaluatedPathwayResults } from 'testUtils/MockedValues';
+import { evaluatedPrecondition, evaluatedPathwayResults } from 'testUtils/MockedValues';
 import { Pathway, EvaluatedPathway } from 'pathways-model';
 import MockedPatientRecordsProvider from 'testUtils/MockedPatientRecordsProvider';
 import MockedPatientProvider from 'testUtils/MockedPatientProvider';
@@ -57,10 +57,10 @@ describe('<PathwaysList />', () => {
   });
 
   it('renders list of pathways', async () => {
-    (evaluatePathwayCriteria as jest.Mock)
-      .mockResolvedValueOnce(evaluatedCriteria[0])
-      .mockResolvedValueOnce(evaluatedCriteria[1])
-      .mockResolvedValueOnce(evaluatedCriteria[2]);
+    (evaluatePathwayPrecondition as jest.Mock)
+      .mockResolvedValueOnce(evaluatedPrecondition[0])
+      .mockResolvedValueOnce(evaluatedPrecondition[1])
+      .mockResolvedValueOnce(evaluatedPrecondition[2]);
     const result = await renderComponent(
       <PathwaysList
         evaluatedPathways={pathwayList}
@@ -89,10 +89,10 @@ describe('<PathwaysList />', () => {
   it('responds to click events with pathway', async () => {
     // eslint-disable-next-line
     console.error = jest.fn(); // Prevents act warning
-    (evaluatePathwayCriteria as jest.Mock)
-      .mockResolvedValueOnce(evaluatedCriteria[0])
-      .mockResolvedValueOnce(evaluatedCriteria[1])
-      .mockResolvedValueOnce(evaluatedCriteria[2]);
+    (evaluatePathwayPrecondition as jest.Mock)
+      .mockResolvedValueOnce(evaluatedPrecondition[0])
+      .mockResolvedValueOnce(evaluatedPrecondition[1])
+      .mockResolvedValueOnce(evaluatedPrecondition[2]);
     (evaluatePatientOnPathway as jest.Mock).mockResolvedValue(evaluatedPathwayResults);
     let value = '';
     function setValue(text: string): void {

--- a/src/components/PatientRecord/PatientRecord.tsx
+++ b/src/components/PatientRecord/PatientRecord.tsx
@@ -25,7 +25,7 @@ import styles from './PatientRecord.module.scss';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { PreconditionResult } from 'pathways-model';
 import { usePathwayContext } from 'components/PathwayProvider';
-import { evaluatePathwayPrecondition } from 'engine';
+import { evaluatePathwayPreconditions } from 'engine';
 import { McodeElements } from 'mcode';
 
 const recordSections = [
@@ -179,7 +179,7 @@ const Visualizer: FC<VisualizerProps> = ({ recordSection, resourcesByType }) => 
 const PathwayVisualizer: FC = () => {
   const { patientRecords } = usePatientRecords();
   const { evaluatedPathway } = usePathwayContext();
-  const [precondition, setPrecondition] = useState<PreconditionResult | null>(null);
+  const [preconditions, setPreconditions] = useState<PreconditionResult | null>(null);
 
   useEffect(() => {
     // Create a Bundle for the CQL engine and check if patientPath needs to be evaluated
@@ -189,10 +189,10 @@ const PathwayVisualizer: FC = () => {
       entry: patientRecords.map((r: fhir.Resource) => ({ resource: r }))
     };
 
-    // Evaluate pathway precondition
+    // Evaluate pathway preconditions
     if (evaluatedPathway) {
-      evaluatePathwayPrecondition(patient, evaluatedPathway.pathway).then(preconditionResult =>
-        setPrecondition(preconditionResult)
+      evaluatePathwayPreconditions(patient, evaluatedPathway.pathway).then(preconditionResult =>
+        setPreconditions(preconditionResult)
       );
     }
   }, [evaluatedPathway, patientRecords]);
@@ -200,7 +200,7 @@ const PathwayVisualizer: FC = () => {
   return (
     <table>
       <tbody>
-        {precondition?.preconditionResultItems.map(c => (
+        {preconditions?.preconditionResultItems.map(c => (
           <tr key={c.elementName}>
             <td>{c.elementName}</td>
             <td>{c.actual}</td>

--- a/src/components/PatientRecord/PatientRecord.tsx
+++ b/src/components/PatientRecord/PatientRecord.tsx
@@ -23,9 +23,9 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import styles from './PatientRecord.module.scss';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
-import { CriteriaResult } from 'pathways-model';
+import { PreconditionResult } from 'pathways-model';
 import { usePathwayContext } from 'components/PathwayProvider';
-import { evaluatePathwayCriteria } from 'engine';
+import { evaluatePathwayPrecondition } from 'engine';
 import { McodeElements } from 'mcode';
 
 const recordSections = [
@@ -179,7 +179,7 @@ const Visualizer: FC<VisualizerProps> = ({ recordSection, resourcesByType }) => 
 const PathwayVisualizer: FC = () => {
   const { patientRecords } = usePatientRecords();
   const { evaluatedPathway } = usePathwayContext();
-  const [criteria, setCriteria] = useState<CriteriaResult | null>(null);
+  const [precondition, setPrecondition] = useState<PreconditionResult | null>(null);
 
   useEffect(() => {
     // Create a Bundle for the CQL engine and check if patientPath needs to be evaluated
@@ -189,10 +189,10 @@ const PathwayVisualizer: FC = () => {
       entry: patientRecords.map((r: fhir.Resource) => ({ resource: r }))
     };
 
-    // Evaluate pathway criteria
+    // Evaluate pathway precondition
     if (evaluatedPathway) {
-      evaluatePathwayCriteria(patient, evaluatedPathway.pathway).then(criteriaResult =>
-        setCriteria(criteriaResult)
+      evaluatePathwayPrecondition(patient, evaluatedPathway.pathway).then(preconditionResult =>
+        setPrecondition(preconditionResult)
       );
     }
   }, [evaluatedPathway, patientRecords]);
@@ -200,7 +200,7 @@ const PathwayVisualizer: FC = () => {
   return (
     <table>
       <tbody>
-        {criteria?.criteriaResultItems.map(c => (
+        {precondition?.preconditionResultItems.map(c => (
           <tr key={c.elementName}>
             <td>{c.elementName}</td>
             <td>{c.actual}</td>

--- a/src/engine/__tests__/cql-extractor.test.ts
+++ b/src/engine/__tests__/cql-extractor.test.ts
@@ -1,5 +1,5 @@
 import pathway from './fixtures/pathways/sample_pathway.json';
-import { extractNavigationCQL, extractCriteriaCQL } from '../cql-extractor';
+import { extractNavigationCQL, extractPreconditionCQL } from '../cql-extractor';
 
 describe('extractNavigationCQL', () => {
   it('extracts the CQL from a pathway', () => {
@@ -11,10 +11,10 @@ describe('extractNavigationCQL', () => {
   });
 });
 
-describe('extractCriteriaCQL', () => {
-  it('extracts the criteria CQL from a pathway', () => {
+describe('extractPreconditionCQL', () => {
+  it('extracts the precondition CQL from a pathway', () => {
     global.fetch = jest.fn(() => Promise.resolve({ text: () => 'fakeCQL' }));
-    const extractedCQL = extractCriteriaCQL(pathway);
+    const extractedCQL = extractPreconditionCQL(pathway);
     expect(extractedCQL).resolves.toEqual(expect.stringContaining('fakeCQL'));
     expect(extractedCQL).resolves.not.toEqual(expect.stringContaining('flux-capacitor'));
     expect(extractedCQL).resolves.toEqual(

--- a/src/engine/__tests__/fixtures/evaluationResults/sample_pathway/patient1.json
+++ b/src/engine/__tests__/fixtures/evaluationResults/sample_pathway/patient1.json
@@ -1,37 +1,37 @@
 {
   "patientId": "9cbc5bf7-7f16-424c-aebe-af0670f92c27",
-  "currentStates": ["Radiation"],
+  "currentNodes": ["Radiation"],
   "documentation": {
     "Start": {
-      "state": "Start",
+      "node": "Start",
       "onPath": true
     },
     "T-test": {
       "resourceType": "Observation",
       "id": "fc4bd5bf-40be-4407-8679-9e15e342762b",
       "status": "final",
-      "state": "T-test",
+      "node": "T-test",
       "onPath": true
     },
     "Surgery": {
       "resourceType": "Procedure",
       "id": "c3643461-66a8-4bdd-b2e9-5176ec0a833d",
       "status": "completed",
-      "state": "Surgery",
+      "node": "Surgery",
       "onPath": true
     },
     "N-test": {
       "resourceType": "Observation",
       "id": "48b52a74-1d91-4573-b430-2d44af0decbe",
       "status": "final",
-      "state": "N-test",
+      "node": "N-test",
       "onPath": true
     },
     "Radiation": {
       "resourceType": "Procedure",
       "id": "85b3a2f2-8a91-4897-bddc-c60491137b86",
       "status": "completed",
-      "state": "Radiation",
+      "node": "Radiation",
       "onPath": true
     }
   }

--- a/src/engine/__tests__/fixtures/evaluationResults/sample_pathway/patient2.json
+++ b/src/engine/__tests__/fixtures/evaluationResults/sample_pathway/patient2.json
@@ -1,37 +1,37 @@
 {
   "patientId": "5cadf7d1-60ab-40c3-b2c4-5fa77610579d",
-  "currentStates": ["Chemo"],
+  "currentNodes": ["Chemo"],
   "documentation": {
     "Start": {
-      "state": "Start",
+      "node": "Start",
       "onPath": true
     },
     "T-test": {
       "resourceType": "Observation",
       "id": "14000e57-ee21-4433-bc38-0c60211a43bc",
       "status": "final",
-      "state": "T-test",
+      "node": "T-test",
       "onPath": true
     },
     "N-test": {
       "resourceType": "Observation",
       "id": "2466b495-5519-422f-adf7-47e300264802",
       "status": "final",
-      "state": "N-test",
+      "node": "N-test",
       "onPath": true
     },
     "ChemoMedication": {
       "resourceType": "MedicationRequest",
       "id": "793caa90-7c39-4788-a139-ee1dee797188",
       "status": "completed",
-      "state": "ChemoMedication",
+      "node": "ChemoMedication",
       "onPath": true
     },
     "Chemo": {
       "resourceType": "Procedure",
       "id": "924d9023-5abf-4e05-9926-650a85109c90",
       "status": "completed",
-      "state": "Chemo",
+      "node": "Chemo",
       "onPath": true
     }
   }

--- a/src/engine/__tests__/fixtures/evaluationResults/sample_pathway/patient3.json
+++ b/src/engine/__tests__/fixtures/evaluationResults/sample_pathway/patient3.json
@@ -1,16 +1,16 @@
 {
   "patientId": "664c8ded-bb1a-4893-b3ee-90d64fdb7f56",
-  "currentStates": ["N-test"],
+  "currentNodes": ["N-test"],
   "documentation": {
     "Start": {
-      "state": "Start",
+      "node": "Start",
       "onPath": true
     },
     "T-test": {
       "resourceType": "Observation",
       "id": "c958f03c-2f53-4c83-b583-92e5331dff22",
       "status": "final",
-      "state": "T-test",
+      "node": "T-test",
       "onPath": true
     }
   }

--- a/src/engine/__tests__/fixtures/evaluationResults/sample_pathway/patient4.json
+++ b/src/engine/__tests__/fixtures/evaluationResults/sample_pathway/patient4.json
@@ -1,30 +1,30 @@
 {
   "patientId": "06da3260-0780-4e95-b3aa-33600e793a48",
-  "currentStates": ["ChemoMedication"],
+  "currentNodes": ["ChemoMedication"],
   "documentation": {
     "Start": {
-      "state": "Start",
+      "node": "Start",
       "onPath": true
     },
     "T-test": {
       "resourceType": "Observation",
       "id": "4631d473-6a50-497e-9651-ff6b3196d796",
       "status": "final",
-      "state": "T-test",
+      "node": "T-test",
       "onPath": true
     },
     "N-test": {
       "resourceType": "Observation",
       "id": "90e9cdbf-371a-4716-8bac-3b7a207e20a2",
       "status": "final",
-      "state": "N-test",
+      "node": "N-test",
       "onPath": true
     },
     "ChemoMedication": {
       "resourceType": "MedicationRequest",
       "id": "ff997fba-63bb-4115-bb0f-d42a21115517",
       "status": "active",
-      "state": "ChemoMedication",
+      "node": "ChemoMedication",
       "onPath": true
     }
   }

--- a/src/engine/__tests__/fixtures/pathways/graph_layout_test_pathway.json
+++ b/src/engine/__tests__/fixtures/pathways/graph_layout_test_pathway.json
@@ -2,7 +2,7 @@
   "name": "test_breast_cancer",
   "description": "Mock breast cancer pathway used for testing the system",
   "library": "mCODE_Library.cql",
-  "precondition": [
+  "preconditions": [
     {
       "elementName": "Condition",
       "expected": "Breast Cancer",

--- a/src/engine/__tests__/fixtures/pathways/graph_layout_test_pathway.json
+++ b/src/engine/__tests__/fixtures/pathways/graph_layout_test_pathway.json
@@ -9,7 +9,7 @@
       "cql": "\"Primary Cancer Condition\" PrimaryCancer return Tuple{ value: PrimaryCancer.code.text.value, match: PrimaryCancer.code.text.value ~ 'Malignant neoplasm of breast (disorder)' } "
     }
   ],
-  "states": {
+  "nodes": {
     "Start": {
       "label": "Start",
       "transitions": [

--- a/src/engine/__tests__/fixtures/pathways/graph_layout_test_pathway.json
+++ b/src/engine/__tests__/fixtures/pathways/graph_layout_test_pathway.json
@@ -2,7 +2,7 @@
   "name": "test_breast_cancer",
   "description": "Mock breast cancer pathway used for testing the system",
   "library": "mCODE_Library.cql",
-  "criteria": [
+  "precondition": [
     {
       "elementName": "Condition",
       "expected": "Breast Cancer",

--- a/src/engine/__tests__/fixtures/pathways/her2_pathway.json
+++ b/src/engine/__tests__/fixtures/pathways/her2_pathway.json
@@ -2,7 +2,7 @@
   "name": "Early Stage HER2+ (Draft)",
   "description": "Pathway for the Early Stage HER2+ Initial Medical Consult Breast Cancer Pathway. This is a draft pathway.",
   "library": "mCODE_Library.cql",
-  "precondition": [
+  "preconditions": [
     {
       "elementName": "Condition",
       "expected": "Breast Cancer",
@@ -1605,7 +1605,7 @@
             }
          }
       },
-      "precondition":{
+      "preconditions":{
          "library" : {
             "annotation" : [ {
                "startLine" : 54,

--- a/src/engine/__tests__/fixtures/pathways/her2_pathway.json
+++ b/src/engine/__tests__/fixtures/pathways/her2_pathway.json
@@ -2,7 +2,7 @@
   "name": "Early Stage HER2+ (Draft)",
   "description": "Pathway for the Early Stage HER2+ Initial Medical Consult Breast Cancer Pathway. This is a draft pathway.",
   "library": "mCODE_Library.cql",
-  "criteria": [
+  "precondition": [
     {
       "elementName": "Condition",
       "expected": "Breast Cancer",
@@ -1605,7 +1605,7 @@
             }
          }
       },
-      "criteria":{
+      "precondition":{
          "library" : {
             "annotation" : [ {
                "startLine" : 54,

--- a/src/engine/__tests__/fixtures/pathways/her2_pathway.json
+++ b/src/engine/__tests__/fixtures/pathways/her2_pathway.json
@@ -14,7 +14,7 @@
       "cql": "[Observation: \"HER2 [Presence] in Breast cancer specimen by Immune stain\"] Her2 return Tuple{ value: Her2.value.text.value, match: Her2.value.text.value ~ 'Positive' } "
     }
   ],
-  "states": {
+  "nodes": {
     "Start": {
       "label": "Start",
       "transitions": [

--- a/src/engine/__tests__/fixtures/pathways/sample_pathway.json
+++ b/src/engine/__tests__/fixtures/pathways/sample_pathway.json
@@ -2,7 +2,7 @@
   "name": "test_breast_cancer",
   "description": "Mock breast cancer pathway used for testing the system",
   "library": "mCODE_Library.cql",
-  "precondition": [
+  "preconditions": [
     {
       "elementName": "Condition",
       "expected": "Breast Cancer",

--- a/src/engine/__tests__/fixtures/pathways/sample_pathway.json
+++ b/src/engine/__tests__/fixtures/pathways/sample_pathway.json
@@ -9,7 +9,7 @@
       "cql": "\"Primary Cancer Condition\" PrimaryCancer return Tuple{ value: PrimaryCancer.code.text.value, match: PrimaryCancer.code.text.value ~ 'Malignant neoplasm of breast (disorder)' } "
     }
   ],
-  "states": {
+  "nodes": {
     "Start": {
       "label": "Start",
       "transitions": [

--- a/src/engine/__tests__/fixtures/pathways/sample_pathway.json
+++ b/src/engine/__tests__/fixtures/pathways/sample_pathway.json
@@ -2,7 +2,7 @@
   "name": "test_breast_cancer",
   "description": "Mock breast cancer pathway used for testing the system",
   "library": "mCODE_Library.cql",
-  "criteria": [
+  "precondition": [
     {
       "elementName": "Condition",
       "expected": "Breast Cancer",

--- a/src/engine/__tests__/output-results.test.ts
+++ b/src/engine/__tests__/output-results.test.ts
@@ -1,4 +1,4 @@
-import { pathwayData, criteriaData } from '../output-results';
+import { pathwayData, preconditionData } from '../output-results';
 
 import pathway from './fixtures/pathways/sample_pathway.json';
 import { resources } from 'testUtils/MockedValues';
@@ -457,7 +457,7 @@ describe('pathway results translator', () => {
   });
 });
 
-describe('criteria results translator', () => {
+describe('precondition results translator', () => {
   it('matching patient produces correct results', () => {
     const patientData = {
       Patient: {
@@ -473,12 +473,12 @@ describe('criteria results translator', () => {
       ]
     };
 
-    const results = criteriaData(pathway, patientData);
+    const results = preconditionData(pathway, patientData);
 
     expect(results).toEqual({
       pathwayName: 'test_breast_cancer',
       matches: 1,
-      criteriaResultItems: [
+      preconditionResultItems: [
         {
           elementName: 'Condition',
           expected: 'Breast Cancer',
@@ -504,12 +504,12 @@ describe('criteria results translator', () => {
       ]
     };
 
-    const results = criteriaData(pathway, patientData);
+    const results = preconditionData(pathway, patientData);
 
     expect(results).toEqual({
       pathwayName: 'test_breast_cancer',
       matches: 0,
-      criteriaResultItems: [
+      preconditionResultItems: [
         {
           elementName: 'Condition',
           expected: 'Breast Cancer',

--- a/src/engine/__tests__/output-results.test.ts
+++ b/src/engine/__tests__/output-results.test.ts
@@ -54,38 +54,38 @@ describe('pathway results translator', () => {
     };
     const patientPath = pathwayData(pathway, patientData, resources);
 
-    expect(patientPath.currentStates).toStrictEqual(['Radiation']);
+    expect(patientPath.currentNodes).toStrictEqual(['Radiation']);
     expect(patientPath.documentation).toEqual({
       Start: {
-        state: 'Start',
+        node: 'Start',
         onPath: true
       },
       'T-test': {
         resourceType: 'Observation',
         status: 'final',
         id: '1',
-        state: 'T-test',
+        node: 'T-test',
         onPath: true
       },
       Surgery: {
         resourceType: 'Procedure',
         status: 'completed',
         id: '3',
-        state: 'Surgery',
+        node: 'Surgery',
         onPath: true
       },
       'N-test': {
         resourceType: 'Observation',
         status: 'final',
         id: '2',
-        state: 'N-test',
+        node: 'N-test',
         onPath: true
       },
       Radiation: {
         resourceType: 'Procedure',
         status: 'not-done',
         id: '4',
-        state: 'Radiation',
+        node: 'Radiation',
         onPath: true
       }
     });
@@ -135,31 +135,31 @@ describe('pathway results translator', () => {
     };
     const patientPath = pathwayData(pathway, patientData, resources);
 
-    expect(patientPath.currentStates).toStrictEqual(['Surgery']);
+    expect(patientPath.currentNodes).toStrictEqual(['Surgery']);
     expect(patientPath.documentation).toEqual({
       Start: {
-        state: 'Start',
+        node: 'Start',
         onPath: true
       },
       'T-test': {
         resourceType: 'Observation',
         status: 'final',
         id: '1',
-        state: 'T-test',
+        node: 'T-test',
         onPath: true
       },
       'N-test': {
         resourceType: 'Observation',
         status: 'final',
         id: '2',
-        state: 'N-test',
+        node: 'N-test',
         onPath: false
       },
       Surgery: {
         resourceType: 'Procedure',
         status: 'in-progress',
         id: '3',
-        state: 'Surgery',
+        node: 'Surgery',
         onPath: true
       }
     });
@@ -201,24 +201,24 @@ describe('pathway results translator', () => {
     };
     const patientPath = pathwayData(pathway, patientData, resources);
 
-    expect(patientPath.currentStates).toStrictEqual(['N-test']);
+    expect(patientPath.currentNodes).toStrictEqual(['N-test']);
     expect(patientPath.documentation).toEqual({
       Start: {
-        state: 'Start',
+        node: 'Start',
         onPath: true
       },
       'T-test': {
         resourceType: 'Observation',
         status: 'final',
         id: '1',
-        state: 'T-test',
+        node: 'T-test',
         onPath: true
       },
       Chemo: {
         resourceType: 'Procedure',
         status: 'final',
         id: '2',
-        state: 'Chemo',
+        node: 'Chemo',
         onPath: false
       }
     });
@@ -272,38 +272,38 @@ describe('pathway results translator', () => {
     };
     const patientPath = pathwayData(pathway, patientData, resources);
 
-    expect(patientPath.currentStates).toStrictEqual(['Chemo']);
+    expect(patientPath.currentNodes).toStrictEqual(['Chemo']);
     expect(patientPath.documentation).toEqual({
       Start: {
-        state: 'Start',
+        node: 'Start',
         onPath: true
       },
       'T-test': {
         resourceType: 'Observation',
         status: 'final',
         id: '1',
-        state: 'T-test',
+        node: 'T-test',
         onPath: true
       },
       'N-test': {
         resourceType: 'Observation',
         status: 'final',
         id: '2',
-        state: 'N-test',
+        node: 'N-test',
         onPath: true
       },
       ChemoMedication: {
         resourceType: 'MedicationRequest',
         status: 'completed',
         id: '4',
-        state: 'ChemoMedication',
+        node: 'ChemoMedication',
         onPath: true
       },
       Chemo: {
         resourceType: 'Procedure',
         status: 'completed',
         id: '3',
-        state: 'Chemo',
+        node: 'Chemo',
         onPath: true
       }
     });
@@ -353,31 +353,31 @@ describe('pathway results translator', () => {
     };
     const patientPath = pathwayData(pathway, patientData, resources);
 
-    expect(patientPath.currentStates).toStrictEqual(['ChemoMedication']);
+    expect(patientPath.currentNodes).toStrictEqual(['ChemoMedication']);
     expect(patientPath.documentation).toEqual({
       Start: {
-        state: 'Start',
+        node: 'Start',
         onPath: true
       },
       'T-test': {
         resourceType: 'Observation',
         status: 'final',
         id: '1',
-        state: 'T-test',
+        node: 'T-test',
         onPath: true
       },
       'N-test': {
         resourceType: 'Observation',
         status: 'final',
         id: '2',
-        state: 'N-test',
+        node: 'N-test',
         onPath: true
       },
       ChemoMedication: {
         resourceType: 'MedicationRequest',
         status: 'active',
         id: '3',
-        state: 'ChemoMedication',
+        node: 'ChemoMedication',
         onPath: true
       }
     });
@@ -426,31 +426,31 @@ describe('pathway results translator', () => {
     };
     const patientPath = pathwayData(pathway, patientData, resources);
 
-    expect(patientPath.currentStates).toStrictEqual(['Radiation', 'OtherRadiation']);
+    expect(patientPath.currentNodes).toStrictEqual(['Radiation', 'OtherRadiation']);
     expect(patientPath.documentation).toEqual({
       Start: {
-        state: 'Start',
+        node: 'Start',
         onPath: true
       },
       'T-test': {
         resourceType: 'Observation',
         status: 'final',
         id: '1',
-        state: 'T-test',
+        node: 'T-test',
         onPath: true
       },
       Surgery: {
         resourceType: 'Procedure',
         status: 'completed',
         id: '3',
-        state: 'Surgery',
+        node: 'Surgery',
         onPath: true
       },
       'N-test': {
         resourceType: 'Observation',
         status: 'final',
         id: '2',
-        state: 'N-test',
+        node: 'N-test',
         onPath: true
       }
     });

--- a/src/engine/cql-extractor.ts
+++ b/src/engine/cql-extractor.ts
@@ -84,16 +84,16 @@ export function extractNavigationCQL(pathway: Pathway): Promise<string> {
 }
 
 /**
- * Extract the CQL statements from the `precondition` section of the pathway
+ * Extract the CQL statements from the `preconditions` section of the pathway
  * into a snippet ready to be converted to ELM.
  * @param pathway - the entire pathway object
- * @return a string of the CQL for the precondition in the pathway
+ * @return a string of the CQL for the preconditions in the pathway
  */
 export function extractPreconditionCQL(pathway: Pathway): Promise<string> {
   return getFixture(pathway.library).then(library => {
     let cql = library;
     // Loop through each JSON object in the pathway
-    for (const precondition of pathway.precondition) {
+    for (const precondition of pathway.preconditions) {
       const cqlBlock1 = precondition.cql;
       const nextBlock1 = cqlFormat(cqlBlock1, precondition.elementName);
       cql = cqlAdd(cql, nextBlock1);

--- a/src/engine/cql-extractor.ts
+++ b/src/engine/cql-extractor.ts
@@ -1,4 +1,4 @@
-import { Pathway, State } from 'pathways-model';
+import { Pathway, PathwayNode } from 'pathways-model';
 
 export interface CqlObject {
   main: string;
@@ -41,19 +41,19 @@ function cqlAdd(cql: string, cqlBlock: string): string {
 }
 
 /**
- * Helper function to determine if a state has a conditional transition
- * @param state - the JSON object of the desired state on the pathway
- * @return true if state is a conditional transition and false
+ * Helper function to determine if a node has a conditional transition
+ * @param node - the JSON object of the desired node on the pathway
+ * @return true if node is a conditional transition and false
  *                   otherwise
  */
-function isConditional(state: State): boolean {
-  if ('transitions' in state) {
-    return state.transitions.length > 1 ? true : false;
+function isConditional(node: PathwayNode): boolean {
+  if ('transitions' in node) {
+    return node.transitions.length > 1 ? true : false;
   } else return false;
 }
 
 /**
- * Function to extract the CQL code from each state in the pathway and build
+ * Function to extract the CQL code from each node in the pathway and build
  * the CQL code to execute
  * @param pathway - the JSON object of the entire pathway
  * @return a string of the CQL code for the navigational nodes in the pathway
@@ -62,14 +62,14 @@ export function extractNavigationCQL(pathway: Pathway): Promise<string> {
   return getFixture(pathway.library).then(library => {
     let cql = library;
     // Loop through each JSON object in the pathway
-    for (const stateName in pathway.states) {
-      const state = pathway.states[stateName];
-      if ('cql' in state) {
-        const cqlBlock1 = state.cql;
-        const nextBlock1 = cqlFormat(cqlBlock1, stateName);
+    for (const nodeName in pathway.nodes) {
+      const node = pathway.nodes[nodeName];
+      if ('cql' in node) {
+        const cqlBlock1 = node.cql;
+        const nextBlock1 = cqlFormat(cqlBlock1, nodeName);
         cql = cqlAdd(cql, nextBlock1);
-      } else if (isConditional(state)) {
-        for (const transition of state.transitions) {
+      } else if (isConditional(node)) {
+        for (const transition of node.transitions) {
           const condition = transition.condition;
           if (condition) {
             const nextBlock2 = cqlFormat(condition.cql, condition.description);

--- a/src/engine/cql-extractor.ts
+++ b/src/engine/cql-extractor.ts
@@ -84,18 +84,18 @@ export function extractNavigationCQL(pathway: Pathway): Promise<string> {
 }
 
 /**
- * Extract the CQL statements from the `criteria` section of the pathway
+ * Extract the CQL statements from the `precondition` section of the pathway
  * into a snippet ready to be converted to ELM.
  * @param pathway - the entire pathway object
- * @return a string of the CQL for the criteria in the pathway
+ * @return a string of the CQL for the precondition in the pathway
  */
-export function extractCriteriaCQL(pathway: Pathway): Promise<string> {
+export function extractPreconditionCQL(pathway: Pathway): Promise<string> {
   return getFixture(pathway.library).then(library => {
     let cql = library;
     // Loop through each JSON object in the pathway
-    for (const criteria of pathway.criteria) {
-      const cqlBlock1 = criteria.cql;
-      const nextBlock1 = cqlFormat(cqlBlock1, criteria.elementName);
+    for (const precondition of pathway.precondition) {
+      const cqlBlock1 = precondition.cql;
+      const nextBlock1 = cqlFormat(cqlBlock1, precondition.elementName);
       cql = cqlAdd(cql, nextBlock1);
     }
 

--- a/src/engine/cql-extractor.ts
+++ b/src/engine/cql-extractor.ts
@@ -62,11 +62,11 @@ export function extractNavigationCQL(pathway: Pathway): Promise<string> {
   return getFixture(pathway.library).then(library => {
     let cql = library;
     // Loop through each JSON object in the pathway
-    for (const nodeName in pathway.nodes) {
-      const node = pathway.nodes[nodeName];
+    for (const nodeKey in pathway.nodes) {
+      const node = pathway.nodes[nodeKey];
       if ('cql' in node) {
         const cqlBlock1 = node.cql;
-        const nextBlock1 = cqlFormat(cqlBlock1, nodeName);
+        const nextBlock1 = cqlFormat(cqlBlock1, nodeKey);
         cql = cqlAdd(cql, nextBlock1);
       } else if (isConditional(node)) {
         for (const transition of node.transitions) {

--- a/src/engine/evaluate-patient.ts
+++ b/src/engine/evaluate-patient.ts
@@ -1,8 +1,14 @@
-import { extractNavigationCQL, extractCriteriaCQL, CqlObject, Library } from './cql-extractor';
+import { extractNavigationCQL, extractPreconditionCQL, CqlObject, Library } from './cql-extractor';
 import convertCQL, { convertBasicCQL, ElmObject } from './cql-to-elm';
 import executeElm from './elm-executor';
-import { pathwayData, criteriaData } from './output-results';
-import { Pathway, PatientData, PathwayResults, ElmResults, CriteriaResult } from 'pathways-model';
+import { pathwayData, preconditionData } from './output-results';
+import {
+  Pathway,
+  PatientData,
+  PathwayResults,
+  ElmResults,
+  PreconditionResult
+} from 'pathways-model';
 import { getFixture } from './cql-extractor';
 import { extractCQLInclude } from 'utils/regexes';
 import { DomainResource, Bundle } from 'fhir-objects';
@@ -31,21 +37,21 @@ export function evaluatePatientOnPathway(
 }
 
 /**
- * Evaluate the pathway criteria against the given patient.
+ * Evaluate the pathway precondition against the given patient.
  * @param patientRecord - Patient's record as FHIR data
  * @param pathway - entire Pathway object
- * @return a list of CriteriaResults, each containing
- *         the expected value and actual value for one criteria item
+ * @return a list of PreconditionResults, each containing
+ *         the expected value and actual value for one precondition item
  */
-export function evaluatePathwayCriteria(
+export function evaluatePathwayPrecondition(
   patientRecord: Bundle,
   pathway: Pathway
-): Promise<CriteriaResult> {
-  const patientDataPromise = pathway.elm?.criteria
-    ? processELMCommon(patientRecord, pathway.elm.criteria)
-    : extractCriteriaCQL(pathway).then(cql => processCQLCommon(patientRecord, cql));
+): Promise<PreconditionResult> {
+  const patientDataPromise = pathway.elm?.precondition
+    ? processELMCommon(patientRecord, pathway.elm.precondition)
+    : extractPreconditionCQL(pathway).then(cql => processCQLCommon(patientRecord, cql));
 
-  return patientDataPromise.then(patientData => criteriaData(pathway, patientData));
+  return patientDataPromise.then(patientData => preconditionData(pathway, patientData));
 }
 
 /**

--- a/src/engine/evaluate-patient.ts
+++ b/src/engine/evaluate-patient.ts
@@ -37,18 +37,18 @@ export function evaluatePatientOnPathway(
 }
 
 /**
- * Evaluate the pathway precondition against the given patient.
+ * Evaluate the pathway preconditions against the given patient.
  * @param patientRecord - Patient's record as FHIR data
  * @param pathway - entire Pathway object
  * @return a list of PreconditionResults, each containing
  *         the expected value and actual value for one precondition item
  */
-export function evaluatePathwayPrecondition(
+export function evaluatePathwayPreconditions(
   patientRecord: Bundle,
   pathway: Pathway
 ): Promise<PreconditionResult> {
-  const patientDataPromise = pathway.elm?.precondition
-    ? processELMCommon(patientRecord, pathway.elm.precondition)
+  const patientDataPromise = pathway.elm?.preconditions
+    ? processELMCommon(patientRecord, pathway.elm.preconditions)
     : extractPreconditionCQL(pathway).then(cql => processCQLCommon(patientRecord, cql));
 
   return patientDataPromise.then(patientData => preconditionData(pathway, patientData));

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,1 +1,1 @@
-export { evaluatePatientOnPathway, evaluatePathwayCriteria } from './evaluate-patient';
+export { evaluatePatientOnPathway, evaluatePathwayPrecondition } from './evaluate-patient';

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,1 +1,1 @@
-export { evaluatePatientOnPathway, evaluatePathwayPrecondition } from './evaluate-patient';
+export { evaluatePatientOnPathway, evaluatePathwayPreconditions } from './evaluate-patient';

--- a/src/engine/output-results.ts
+++ b/src/engine/output-results.ts
@@ -8,7 +8,7 @@ import {
   PreconditionResult,
   DocumentationResource,
   PathwayNode,
-  PathwayActionNode,
+  ActionNode,
   PreconditionResultItem,
   Documentation
 } from 'pathways-model';
@@ -84,7 +84,7 @@ export function pathwayData(
 }
 
 /**
- * Engine function to take in the ELM patient results and output data relating to the pathway precondition
+ * Engine function to take in the ELM patient results and output data relating to the pathway preconditions
  * @param pathway - the entire pathway
  * @param patientData - the data on the patient from a CQL execution. Note this is a single patient not the entire patientResults object
  * @return returns PreconditionResult containing the expected and actual value for one data element
@@ -93,7 +93,7 @@ export function preconditionData(pathway: Pathway, patientData: PatientData): Pr
   const resultItems: PreconditionResultItem[] = [];
 
   let matches = 0;
-  pathway.precondition.forEach(precondition => {
+  pathway.preconditions.forEach(precondition => {
     let evaluationResult = patientData[precondition.elementName];
     if (Array.isArray(evaluationResult)) {
       evaluationResult = evaluationResult[0]; // TODO: add functionality for multiple resources
@@ -322,7 +322,7 @@ function nextNode(
   currentNodeKey: string,
   resources: DomainResource[]
 ): NodeData | null {
-  const currentNode: PathwayNode | PathwayActionNode = pathway.nodes[currentNodeKey];
+  const currentNode: PathwayNode | ActionNode = pathway.nodes[currentNodeKey];
   if ('action' in currentNode) {
     let resource = patientData[currentNodeKey];
     if (resource?.length) {

--- a/src/engine/output-results.ts
+++ b/src/engine/output-results.ts
@@ -5,11 +5,11 @@ import {
   Pathway,
   PathwayResults,
   PatientData,
-  CriteriaResult,
+  PreconditionResult,
   DocumentationResource,
   PathwayNode,
   GuidanceNode,
-  CriteriaResultItem,
+  PreconditionResultItem,
   Documentation
 } from 'pathways-model';
 import { DocumentReference, DomainResource } from 'fhir-objects';
@@ -84,17 +84,17 @@ export function pathwayData(
 }
 
 /**
- * Engine function to take in the ELM patient results and output data relating to the pathway criteria
+ * Engine function to take in the ELM patient results and output data relating to the pathway precondition
  * @param pathway - the entire pathway
  * @param patientData - the data on the patient from a CQL execution. Note this is a single patient not the entire patientResults object
- * @return returns CriteriaResult containing the expected and actual value for one data element
+ * @return returns PreconditionResult containing the expected and actual value for one data element
  */
-export function criteriaData(pathway: Pathway, patientData: PatientData): CriteriaResult {
-  const resultItems: CriteriaResultItem[] = [];
+export function preconditionData(pathway: Pathway, patientData: PatientData): PreconditionResult {
+  const resultItems: PreconditionResultItem[] = [];
 
   let matches = 0;
-  pathway.criteria.forEach(criteria => {
-    let evaluationResult = patientData[criteria.elementName];
+  pathway.precondition.forEach(precondition => {
+    let evaluationResult = patientData[precondition.elementName];
     if (Array.isArray(evaluationResult)) {
       evaluationResult = evaluationResult[0]; // TODO: add functionality for multiple resources
     }
@@ -108,20 +108,20 @@ export function criteriaData(pathway: Pathway, patientData: PatientData): Criter
 
     if (match) matches += 1;
 
-    const criteriaResultItem = {
-      elementName: criteria.elementName,
-      expected: criteria.expected,
+    const preconditionResultItem = {
+      elementName: precondition.elementName,
+      expected: precondition.expected,
       actual,
       match
     };
 
-    resultItems.push(criteriaResultItem);
+    resultItems.push(preconditionResultItem);
   });
 
   return {
     pathwayName: pathway.name,
     matches: matches,
-    criteriaResultItems: resultItems
+    preconditionResultItems: resultItems
   };
 }
 

--- a/src/engine/output-results.ts
+++ b/src/engine/output-results.ts
@@ -8,7 +8,7 @@ import {
   PreconditionResult,
   DocumentationResource,
   PathwayNode,
-  GuidanceNode,
+  ActionNode,
   PreconditionResultItem,
   Documentation
 } from 'pathways-model';
@@ -322,7 +322,7 @@ function nextNode(
   currentNodeName: string,
   resources: DomainResource[]
 ): NodeData | null {
-  const currentNode: PathwayNode | GuidanceNode = pathway.nodes[currentNodeName];
+  const currentNode: PathwayNode | ActionNode = pathway.nodes[currentNodeName];
   if ('action' in currentNode) {
     let resource = patientData[currentNodeName];
     if (resource?.length) {

--- a/src/engine/output-results.ts
+++ b/src/engine/output-results.ts
@@ -8,7 +8,7 @@ import {
   PreconditionResult,
   DocumentationResource,
   PathwayNode,
-  ActionNode,
+  PathwayActionNode,
   PreconditionResultItem,
   Documentation
 } from 'pathways-model';
@@ -322,7 +322,7 @@ function nextNode(
   currentNodeKey: string,
   resources: DomainResource[]
 ): NodeData | null {
-  const currentNode: PathwayNode | ActionNode = pathway.nodes[currentNodeKey];
+  const currentNode: PathwayNode | PathwayActionNode = pathway.nodes[currentNodeKey];
   if ('action' in currentNode) {
     let resource = patientData[currentNodeKey];
     if (resource?.length) {

--- a/src/testUtils/MockedPathwayProvider.tsx
+++ b/src/testUtils/MockedPathwayProvider.tsx
@@ -10,7 +10,7 @@ interface PathwayProviderProps {
 const pathway: Pathway = {
   name: 'Test Pathway',
   library: 'mCODE_Library.cql',
-  criteria: [
+  precondition: [
     {
       elementName: 'condition',
       expected: 'breast cancer',

--- a/src/testUtils/MockedPathwayProvider.tsx
+++ b/src/testUtils/MockedPathwayProvider.tsx
@@ -10,7 +10,7 @@ interface PathwayProviderProps {
 const pathway: Pathway = {
   name: 'Test Pathway',
   library: 'mCODE_Library.cql',
-  precondition: [
+  preconditions: [
     {
       elementName: 'condition',
       expected: 'breast cancer',

--- a/src/testUtils/MockedPathwayProvider.tsx
+++ b/src/testUtils/MockedPathwayProvider.tsx
@@ -17,7 +17,7 @@ const pathway: Pathway = {
       cql: 'some fancy CQL statement'
     }
   ],
-  states: {
+  nodes: {
     Start: {
       label: 'Start',
       transitions: []

--- a/src/testUtils/MockedValues.ts
+++ b/src/testUtils/MockedValues.ts
@@ -1,4 +1,4 @@
-import { CriteriaResult, PathwayResults } from 'pathways-model';
+import { PreconditionResult, PathwayResults } from 'pathways-model';
 
 export const resources: fhir.DomainResource[] = [
   {
@@ -12,11 +12,11 @@ export const resources: fhir.DomainResource[] = [
   }
 ];
 
-export const evaluatedCriteria: CriteriaResult[] = [
+export const evaluatedPrecondition: PreconditionResult[] = [
   {
     pathwayName: 'test1',
     matches: 1,
-    criteriaResultItems: [
+    preconditionResultItems: [
       {
         elementName: 'condition',
         expected: 'breast Cancer',
@@ -28,7 +28,7 @@ export const evaluatedCriteria: CriteriaResult[] = [
   {
     pathwayName: 'test2',
     matches: 0,
-    criteriaResultItems: [
+    preconditionResultItems: [
       {
         elementName: 'condition',
         expected: 'gist Cancer',
@@ -40,7 +40,7 @@ export const evaluatedCriteria: CriteriaResult[] = [
   {
     pathwayName: 'test3',
     matches: 0,
-    criteriaResultItems: [
+    preconditionResultItems: [
       {
         elementName: 'condition',
         expected: 'lung Cancer',

--- a/src/testUtils/MockedValues.ts
+++ b/src/testUtils/MockedValues.ts
@@ -12,7 +12,7 @@ export const resources: fhir.DomainResource[] = [
   }
 ];
 
-export const evaluatedPrecondition: PreconditionResult[] = [
+export const evaluatedPreconditions: PreconditionResult[] = [
   {
     pathwayName: 'test1',
     matches: 1,

--- a/src/testUtils/MockedValues.ts
+++ b/src/testUtils/MockedValues.ts
@@ -53,10 +53,10 @@ export const evaluatedCriteria: CriteriaResult[] = [
 
 export const evaluatedPathwayResults: PathwayResults = {
   patientId: '1',
-  currentStates: ['Start'],
+  currentNodes: ['Start'],
   documentation: {
     Start: {
-      state: 'Start',
+      node: 'Start',
       onPath: true
     }
   }

--- a/src/testUtils/services.ts
+++ b/src/testUtils/services.ts
@@ -19,7 +19,7 @@ export const loadedService: Service<Array<Pathway>> = {
           cql: 'some fancy CQL statement'
         }
       ],
-      states: {
+      nodes: {
         Start: {
           label: 'Start',
           transitions: []
@@ -37,7 +37,7 @@ export const loadedService: Service<Array<Pathway>> = {
           cql: 'some fancy CQL statement'
         }
       ],
-      states: {
+      nodes: {
         Start: {
           label: 'Start',
           transitions: []
@@ -55,7 +55,7 @@ export const loadedService: Service<Array<Pathway>> = {
           cql: 'some fancy CQL statement'
         }
       ],
-      states: {
+      nodes: {
         Start: {
           label: 'Start',
           transitions: []

--- a/src/testUtils/services.ts
+++ b/src/testUtils/services.ts
@@ -12,7 +12,7 @@ export const loadedService: Service<Array<Pathway>> = {
       name: 'test1',
       description: 'test1',
       library: 'test.cql',
-      criteria: [
+      precondition: [
         {
           elementName: 'condition',
           expected: 'breast cancer',
@@ -30,7 +30,7 @@ export const loadedService: Service<Array<Pathway>> = {
       name: 'test2',
       description: 'test2',
       library: 'test.cql',
-      criteria: [
+      precondition: [
         {
           elementName: 'condition',
           expected: 'gist cancer',
@@ -48,7 +48,7 @@ export const loadedService: Service<Array<Pathway>> = {
       name: 'test3',
       description: 'test3',
       library: 'test.cql',
-      criteria: [
+      precondition: [
         {
           elementName: 'condition',
           expected: 'lung cancer',

--- a/src/testUtils/services.ts
+++ b/src/testUtils/services.ts
@@ -12,7 +12,7 @@ export const loadedService: Service<Array<Pathway>> = {
       name: 'test1',
       description: 'test1',
       library: 'test.cql',
-      precondition: [
+      preconditions: [
         {
           elementName: 'condition',
           expected: 'breast cancer',
@@ -30,7 +30,7 @@ export const loadedService: Service<Array<Pathway>> = {
       name: 'test2',
       description: 'test2',
       library: 'test.cql',
-      precondition: [
+      preconditions: [
         {
           elementName: 'condition',
           expected: 'gist cancer',
@@ -48,7 +48,7 @@ export const loadedService: Service<Array<Pathway>> = {
       name: 'test3',
       description: 'test3',
       library: 'test.cql',
-      precondition: [
+      preconditions: [
         {
           elementName: 'condition',
           expected: 'lung cancer',

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -4,7 +4,7 @@ declare module 'pathways-model' {
     name: string;
     description?: string;
     library: string;
-    criteria: Criteria[];
+    precondition: Precondition[];
     nodes: {
       [key: string]: GuidanceNode | BranchNode | PathwayNode;
     };
@@ -14,7 +14,7 @@ declare module 'pathways-model' {
 
   export interface PathwayELM {
     navigational?: object;
-    criteria?: object;
+    precondition?: object;
   }
 
   export interface EvaluatedPathway {
@@ -22,7 +22,7 @@ declare module 'pathways-model' {
     pathwayResults: PathwayResults | null;
   }
 
-  export interface Criteria {
+  export interface Precondition {
     elementName: string; // name of the mCODE element
     expected: string; // human readable value
     cql: string; // cql to fetch the value from a patient
@@ -64,9 +64,9 @@ declare module 'pathways-model' {
     };
   }
 
-  export interface CriteriaResultItem {
-    // doesn't extend Criteria because we don't care about the cql here,
-    // and don't want to make it optional in Criteria
+  export interface PreconditionResultItem {
+    // doesn't extend Precondition because we don't care about the cql here,
+    // and don't want to make it optional in Precondition
 
     elementName: string; // name of the mCODE element
     expected: string; // human readable value
@@ -74,10 +74,10 @@ declare module 'pathways-model' {
     match: boolean; // in case expected !== actual but they are still a match
   }
 
-  export interface CriteriaResult {
+  export interface PreconditionResult {
     pathwayName: string;
     matches: number;
-    criteriaResultItems: CriteriaResultItem[];
+    preconditionResultItems: PreconditionResultItem[];
   }
 
   export interface ElmResults {

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -6,7 +6,7 @@ declare module 'pathways-model' {
     library: string;
     precondition: Precondition[];
     nodes: {
-      [key: string]: GuidanceNode | BranchNode | PathwayNode;
+      [key: string]: ActionNode | BranchNode | PathwayNode;
     };
     elm?: PathwayELM;
     // TODO: this should not be optional once we have the pathway builder
@@ -33,7 +33,7 @@ declare module 'pathways-model' {
     transitions: Transition[];
   }
 
-  export interface GuidanceNode extends PathwayNode {
+  export interface ActionNode extends PathwayNode {
     cql: string;
     action: Action[];
   }

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -5,8 +5,8 @@ declare module 'pathways-model' {
     description?: string;
     library: string;
     criteria: Criteria[];
-    states: {
-      [key: string]: GuidanceState | BranchState | State;
+    nodes: {
+      [key: string]: GuidanceNode | BranchNode | PathwayNode;
     };
     elm?: PathwayELM;
     // TODO: this should not be optional once we have the pathway builder
@@ -28,12 +28,12 @@ declare module 'pathways-model' {
     cql: string; // cql to fetch the value from a patient
   }
 
-  export interface State {
+  export interface PathwayNode {
     label: string;
     transitions: Transition[];
   }
 
-  export interface GuidanceState extends State {
+  export interface GuidanceNode extends PathwayNode {
     cql: string;
     action: Action[];
   }
@@ -58,7 +58,7 @@ declare module 'pathways-model' {
 
   export interface PathwayResults {
     patientId: string;
-    currentStates: string[];
+    currentNodes: string[];
     documentation: {
       [key: string]: Documentation;
     };
@@ -96,7 +96,7 @@ declare module 'pathways-model' {
   }
 
   export interface Documentation {
-    state: string;
+    node: string;
     onPath: boolean;
   }
 

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -6,7 +6,7 @@ declare module 'pathways-model' {
     library: string;
     precondition: Precondition[];
     nodes: {
-      [key: string]: ActionNode | BranchNode | PathwayNode;
+      [key: string]: PathwayActionNode | BranchNode | PathwayNode;
     };
     elm?: PathwayELM;
     // TODO: this should not be optional once we have the pathway builder
@@ -33,7 +33,7 @@ declare module 'pathways-model' {
     transitions: Transition[];
   }
 
-  export interface ActionNode extends PathwayNode {
+  export interface PathwayActionNode extends PathwayNode {
     cql: string;
     action: Action[];
   }

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -38,8 +38,8 @@ declare module 'pathways-model' {
     action: Action[];
   }
 
-  // NOTE: the model also includes a BranchState (which extends State),
-  // but as of right now it has no additional fields not in State,
+  // NOTE: the model also includes a BranchNode (which extends PathwayNode),
+  // but as of right now it has no additional fields not in PathwayNode,
   // and TypeScript does not allow "empty" interfaces so we can't add it yet.
   // Add it here if/when we ever need it.
 

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -4,9 +4,9 @@ declare module 'pathways-model' {
     name: string;
     description?: string;
     library: string;
-    precondition: Precondition[];
+    preconditions: Precondition[];
     nodes: {
-      [key: string]: PathwayActionNode | BranchNode | PathwayNode;
+      [key: string]: ActionNode | BranchNode | PathwayNode;
     };
     elm?: PathwayELM;
     // TODO: this should not be optional once we have the pathway builder
@@ -14,7 +14,7 @@ declare module 'pathways-model' {
 
   export interface PathwayELM {
     navigational?: object;
-    precondition?: object;
+    preconditions?: object;
   }
 
   export interface EvaluatedPathway {
@@ -33,7 +33,7 @@ declare module 'pathways-model' {
     transitions: Transition[];
   }
 
-  export interface PathwayActionNode extends PathwayNode {
+  export interface ActionNode extends PathwayNode {
     cql: string;
     action: Action[];
   }

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -127,13 +127,13 @@ export function createNoteContent(
   patientRecords: DomainResource[],
   status: string,
   notes: string,
-  pathwayNode?: ActionNode
+  actionNode?: ActionNode
 ): string {
   note.status = status;
   note.notes = notes;
-  if (pathwayNode) {
-    note.treatment = pathwayNode.action[0].description;
-    note.node = pathwayNode.label;
+  if (actionNode) {
+    note.treatment = actionNode.action[0].description;
+    note.node = actionNode.label;
   }
 
   const tnm: string[] = ['', '', ''];

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -1,4 +1,4 @@
-import { GuidanceNode, EvaluatedPathway, Pathway } from 'pathways-model';
+import { ActionNode, EvaluatedPathway, Pathway } from 'pathways-model';
 import { Note, toString } from 'components/NoteDataProvider';
 import {
   Patient,
@@ -127,7 +127,7 @@ export function createNoteContent(
   patientRecords: DomainResource[],
   status: string,
   notes: string,
-  pathwayNode?: GuidanceNode
+  pathwayNode?: ActionNode
 ): string {
   note.status = status;
   note.notes = notes;

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -1,4 +1,4 @@
-import { GuidanceState, EvaluatedPathway, Pathway } from 'pathways-model';
+import { GuidanceNode, EvaluatedPathway, Pathway } from 'pathways-model';
 import { Note, toString } from 'components/NoteDataProvider';
 import {
   Patient,
@@ -127,13 +127,13 @@ export function createNoteContent(
   patientRecords: DomainResource[],
   status: string,
   notes: string,
-  pathwayState?: GuidanceState
+  pathwayNode?: GuidanceNode
 ): string {
   note.status = status;
   note.notes = notes;
-  if (pathwayState) {
-    note.treatment = pathwayState.action[0].description;
-    note.node = pathwayState.label;
+  if (pathwayNode) {
+    note.treatment = pathwayNode.action[0].description;
+    note.node = pathwayNode.label;
   }
 
   const tnm: string[] = ['', '', ''];

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -1,4 +1,4 @@
-import { ActionNode, EvaluatedPathway, Pathway } from 'pathways-model';
+import { PathwayActionNode, EvaluatedPathway, Pathway } from 'pathways-model';
 import { Note, toString } from 'components/NoteDataProvider';
 import {
   Patient,
@@ -127,7 +127,7 @@ export function createNoteContent(
   patientRecords: DomainResource[],
   status: string,
   notes: string,
-  actionNode?: ActionNode
+  actionNode?: PathwayActionNode
 ): string {
   note.status = status;
   note.notes = notes;

--- a/src/utils/fhirUtils.ts
+++ b/src/utils/fhirUtils.ts
@@ -1,4 +1,4 @@
-import { PathwayActionNode, EvaluatedPathway, Pathway } from 'pathways-model';
+import { ActionNode, EvaluatedPathway, Pathway } from 'pathways-model';
 import { Note, toString } from 'components/NoteDataProvider';
 import {
   Patient,
@@ -127,7 +127,7 @@ export function createNoteContent(
   patientRecords: DomainResource[],
   status: string,
   notes: string,
-  actionNode?: PathwayActionNode
+  actionNode?: ActionNode
 ): string {
   note.status = status;
   note.notes = notes;

--- a/src/utils/nodeUtils.ts
+++ b/src/utils/nodeUtils.ts
@@ -1,10 +1,10 @@
-import { PathwayNode, GuidanceNode } from 'pathways-model';
+import { PathwayNode, ActionNode } from 'pathways-model';
 
-export function isGuidanceNode(node: PathwayNode): boolean {
-  const { action } = node as GuidanceNode;
+export function isActionNode(node: PathwayNode): boolean {
+  const { action } = node as ActionNode;
   return action ? action.length > 0 : false;
 }
 
 export function isBranchNode(node: PathwayNode): boolean {
-  return !isGuidanceNode(node) && node.transitions.length > 1;
+  return !isActionNode(node) && node.transitions.length > 1;
 }

--- a/src/utils/nodeUtils.ts
+++ b/src/utils/nodeUtils.ts
@@ -1,7 +1,7 @@
-import { PathwayNode, ActionNode } from 'pathways-model';
+import { PathwayNode, PathwayActionNode } from 'pathways-model';
 
 export function isActionNode(node: PathwayNode): boolean {
-  const { action } = node as ActionNode;
+  const { action } = node as PathwayActionNode;
   return action ? action.length > 0 : false;
 }
 

--- a/src/utils/nodeUtils.ts
+++ b/src/utils/nodeUtils.ts
@@ -1,7 +1,7 @@
-import { PathwayNode, PathwayActionNode } from 'pathways-model';
+import { PathwayNode, ActionNode } from 'pathways-model';
 
 export function isActionNode(node: PathwayNode): boolean {
-  const { action } = node as PathwayActionNode;
+  const { action } = node as ActionNode;
   return action ? action.length > 0 : false;
 }
 

--- a/src/utils/nodeUtils.ts
+++ b/src/utils/nodeUtils.ts
@@ -1,10 +1,10 @@
-import { State, GuidanceState } from 'pathways-model';
+import { PathwayNode, GuidanceNode } from 'pathways-model';
 
-export function isGuidanceState(state: State): boolean {
-  const { action } = state as GuidanceState;
+export function isGuidanceNode(node: PathwayNode): boolean {
+  const { action } = node as GuidanceNode;
   return action ? action.length > 0 : false;
 }
 
-export function isBranchState(state: State): boolean {
-  return !isGuidanceState(state) && state.transitions.length > 1;
+export function isBranchNode(node: PathwayNode): boolean {
+  return !isGuidanceNode(node) && node.transitions.length > 1;
 }

--- a/src/visualization/__tests__/fixtures/pathways/graph_layout_test_pathway.json
+++ b/src/visualization/__tests__/fixtures/pathways/graph_layout_test_pathway.json
@@ -2,7 +2,7 @@
   "name": "test_breast_cancer",
   "description": "Mock breast cancer pathway used for testing the system",
   "library": "mCODE_Library.cql",
-  "states": {
+  "nodes": {
     "Start": {
       "label": "Start",
       "transitions": [

--- a/src/visualization/__tests__/fixtures/pathways/her2_pathway.json
+++ b/src/visualization/__tests__/fixtures/pathways/her2_pathway.json
@@ -2,7 +2,7 @@
     "name": "Breast Cancer Pathway: Early Stage HER2+ Pathway",
     "description": "Pathway for the Early Stage HER2+ Initial Medical Consult Breast Cancer Pathway",
     "library": "her2_library.cql",
-    "states": {
+    "nodes": {
       "Start": {
         "label": "Start",
         "transitions": [

--- a/src/visualization/__tests__/fixtures/pathways/sample_pathway.json
+++ b/src/visualization/__tests__/fixtures/pathways/sample_pathway.json
@@ -2,7 +2,7 @@
   "name": "test_breast_cancer",
   "description": "Mock breast cancer pathway used for testing the system",
   "library": "mCODE_Library.cql",
-  "states": {
+  "nodes": {
     "Start": {
       "label": "Start",
       "transitions": [

--- a/src/visualization/__tests__/graph-layout.test.ts
+++ b/src/visualization/__tests__/graph-layout.test.ts
@@ -24,18 +24,18 @@ describe('pathway graph layout', () => {
   // Helper function to validate layout output
   function checkLayout(graphCoordinates: NodeCoordinates): void {
     // Verify every node has (x,y) and only start has y: 0
-    for (const nodeName in graphCoordinates) {
+    for (const nodeKey in graphCoordinates) {
       // Validate node
-      const coords = graphCoordinates[nodeName];
+      const coords = graphCoordinates[nodeKey];
       expect(coords).toBeDefined();
       expect(coords.x).toBeDefined();
       expect(coords.y).toBeDefined();
-      if (nodeName !== 'Start') expect(coords.y !== 0).toBeTruthy();
+      if (nodeKey !== 'Start') expect(coords.y !== 0).toBeTruthy();
 
       // Validate node does not overlap with another node
-      for (const otherNodeName in graphCoordinates) {
-        if (nodeName !== otherNodeName) {
-          const otherCoords = graphCoordinates[otherNodeName];
+      for (const otherNodeKey in graphCoordinates) {
+        if (nodeKey !== otherNodeKey) {
+          const otherCoords = graphCoordinates[otherNodeKey];
           expect(coords.x === otherCoords.x && coords.y === otherCoords.y).toBeFalsy();
         }
       }

--- a/src/visualization/layout.ts
+++ b/src/visualization/layout.ts
@@ -1,7 +1,7 @@
 /* eslint-disable guard-for-in */
 /* eslint-disable max-len */
 
-import { Pathway, State } from 'pathways-model';
+import { Pathway, PathwayNode } from 'pathways-model';
 import { Node, Nodes, Layout, NodeCoordinates, Edges, NodeDimensions } from 'graph-model';
 
 import dagre from 'dagre';
@@ -28,31 +28,31 @@ function layoutDagre(pathway: Pathway, nodeDimensions: NodeDimensions): Layout {
   const START = 'Start';
   const NODE_HEIGHT = 50;
   const NODE_WIDTH_FACTOR = 10; // factor to convert label length => width, assume font size roughly 10
-  const nodeNames = Object.keys(pathway.states);
+  const nodeNames = Object.keys(pathway.nodes);
   const g = new dagre.graphlib.Graph();
 
   g.setGraph({});
   g.setDefaultEdgeLabel(() => ({})); // dagre requires a default edge label, we want it to just be empty
 
-  nodeNames.forEach(stateName => {
-    const state: State = pathway.states[stateName];
-    const nodeDimension = nodeDimensions[stateName];
+  nodeNames.forEach(nodeName => {
+    const node: PathwayNode = pathway.nodes[nodeName];
+    const nodeDimension = nodeDimensions[nodeName];
 
     if (nodeDimension) {
-      g.setNode(stateName, {
-        label: state.label,
+      g.setNode(nodeName, {
+        label: node.label,
         width: nodeDimension.width,
         height: nodeDimension.height
       });
     } else {
-      g.setNode(stateName, {
-        label: state.label,
-        width: state.label.length * NODE_WIDTH_FACTOR,
+      g.setNode(nodeName, {
+        label: node.label,
+        width: node.label.length * NODE_WIDTH_FACTOR,
         height: NODE_HEIGHT
       });
     }
 
-    state.transitions.forEach(transition => {
+    node.transitions.forEach(transition => {
       const label = transition.condition
         ? {
             label: transition.condition.description,
@@ -61,7 +61,7 @@ function layoutDagre(pathway: Pathway, nodeDimensions: NodeDimensions): Layout {
           }
         : {};
 
-      g.setEdge(stateName, transition.transition, label);
+      g.setEdge(nodeName, transition.transition, label);
     });
   });
 
@@ -307,7 +307,7 @@ function layoutCustom(pathway: Pathway): Layout {
    * the children.
    *
    * @param nodes - the Nodes
-   * @param graph - the graph as list of states by level
+   * @param graph - the graph as list of nodes by level
    * @param node - the node to get children from
    * @param rank - the rank to assign to the children
    */
@@ -330,7 +330,7 @@ function layoutCustom(pathway: Pathway): Layout {
   }
 
   /**
-   * Assigns the node labeled by stateName the rank by updating graph and nodes data structures
+   * Assigns the node labeled by nodeName the rank by updating graph and nodes data structures
    *
    * @param nodes - the Nodes
    * @param graph - the graph as list of nodes by level
@@ -357,10 +357,10 @@ function layoutCustom(pathway: Pathway): Layout {
     const nodes: Nodes = {};
 
     // Iniitalize each node with default values
-    let stateName: string;
-    for (stateName in pathway.states) {
-      nodes[stateName] = {
-        label: stateName,
+    let nodeName: string;
+    for (nodeName in pathway.nodes) {
+      nodes[nodeName] = {
+        label: nodeName,
         rank: NaN,
         horizontalPosition: NaN,
         children: [],
@@ -370,14 +370,14 @@ function layoutCustom(pathway: Pathway): Layout {
     }
 
     // Set the child and parent properties of each node
-    Object.keys(pathway.states).forEach(stateName => {
-      const state: State = pathway.states[stateName];
+    Object.keys(pathway.nodes).forEach(nodeName => {
+      const node: PathwayNode = pathway.nodes[nodeName];
 
-      state.transitions.forEach(transition => {
-        if (!nodes[stateName].children.includes(transition.transition))
-          nodes[stateName].children.push(transition.transition);
-        if (!nodes[transition.transition].parents.includes(stateName))
-          nodes[transition.transition].parents.push(stateName);
+      node.transitions.forEach(transition => {
+        if (!nodes[nodeName].children.includes(transition.transition))
+          nodes[nodeName].children.push(transition.transition);
+        if (!nodes[transition.transition].parents.includes(nodeName))
+          nodes[transition.transition].parents.push(nodeName);
       });
     });
 

--- a/src/visualization/layout.ts
+++ b/src/visualization/layout.ts
@@ -28,24 +28,24 @@ function layoutDagre(pathway: Pathway, nodeDimensions: NodeDimensions): Layout {
   const START = 'Start';
   const NODE_HEIGHT = 50;
   const NODE_WIDTH_FACTOR = 10; // factor to convert label length => width, assume font size roughly 10
-  const nodeNames = Object.keys(pathway.nodes);
+  const nodeKeys = Object.keys(pathway.nodes);
   const g = new dagre.graphlib.Graph();
 
   g.setGraph({});
   g.setDefaultEdgeLabel(() => ({})); // dagre requires a default edge label, we want it to just be empty
 
-  nodeNames.forEach(nodeName => {
-    const node: PathwayNode = pathway.nodes[nodeName];
-    const nodeDimension = nodeDimensions[nodeName];
+  nodeKeys.forEach(nodeKey => {
+    const node: PathwayNode = pathway.nodes[nodeKey];
+    const nodeDimension = nodeDimensions[nodeKey];
 
     if (nodeDimension) {
-      g.setNode(nodeName, {
+      g.setNode(nodeKey, {
         label: node.label,
         width: nodeDimension.width,
         height: nodeDimension.height
       });
     } else {
-      g.setNode(nodeName, {
+      g.setNode(nodeKey, {
         label: node.label,
         width: node.label.length * NODE_WIDTH_FACTOR,
         height: NODE_HEIGHT
@@ -61,7 +61,7 @@ function layoutDagre(pathway: Pathway, nodeDimensions: NodeDimensions): Layout {
           }
         : {};
 
-      g.setEdge(nodeName, transition.transition, label);
+      g.setEdge(nodeKey, transition.transition, label);
     });
   });
 
@@ -69,12 +69,12 @@ function layoutDagre(pathway: Pathway, nodeDimensions: NodeDimensions): Layout {
   const nodeCoordinates: NodeCoordinates = {};
   const startNodeShift = g.node(START).x;
 
-  for (const nodeName of nodeNames) {
-    const node = g.node(nodeName);
+  for (const nodeKey of nodeKeys) {
+    const node = g.node(nodeKey);
     // dagre returns coordinates for the center of the node,
     // our renderer expects coordinates for the corner of the node.
     // further, our renderer expects the Start node to be centered at x: 0
-    nodeCoordinates[nodeName] = {
+    nodeCoordinates[nodeKey] = {
       x: node.x - startNodeShift - node.width / 2,
       y: node.y - node.height / 2
     };
@@ -121,9 +121,9 @@ function layoutCustom(pathway: Pathway): Layout {
   let rank = 0;
   do {
     // Iterate over each node on the current level
-    for (const nodeName of graph[rank]) {
+    for (const nodeKey of graph[rank]) {
       // Assign all children to the next rank
-      assignRankToChildren(nodes[nodeName], rank + 1);
+      assignRankToChildren(nodes[nodeKey], rank + 1);
     }
 
     rank++;
@@ -153,9 +153,9 @@ function layoutCustom(pathway: Pathway): Layout {
   function produceCoordinates(): NodeCoordinates {
     const coordinates: NodeCoordinates = {};
 
-    for (const nodeName in nodes) {
-      const node = nodes[nodeName];
-      coordinates[nodeName] = {
+    for (const nodeKey in nodes) {
+      const node = nodes[nodeKey];
+      coordinates[nodeKey] = {
         x: node.horizontalPosition,
         y: node.rank * VERTICAL_OFFSET
       };
@@ -202,7 +202,7 @@ function layoutCustom(pathway: Pathway): Layout {
   }
 
   /**
-   * Assigns the node given by nodeName the horizontal position hPos if it is not already set
+   * Assigns the node given by nodeKey the horizontal position hPos if it is not already set
    * @param node - the node to set the horizontal position of
    * @param hPos - the horizontal position for the node
    */
@@ -228,8 +228,8 @@ function layoutCustom(pathway: Pathway): Layout {
    * @param rank - the level of the graph to assign node positions of
    */
   function assignHorizontalPositionToNodesInRank(rank: number): void {
-    for (const nodeName of graph[rank]) {
-      const node = nodes[nodeName];
+    for (const nodeKey of graph[rank]) {
+      const node = nodes[nodeKey];
       if (!isNaN(node.horizontalPosition)) continue;
       const parentsOnHigherRank = node.parents.filter(p => nodes[p].rank < node.rank);
       if (parentsOnHigherRank.length === 1) {
@@ -330,20 +330,20 @@ function layoutCustom(pathway: Pathway): Layout {
   }
 
   /**
-   * Assigns the node labeled by nodeName the rank by updating graph and nodes data structures
+   * Assigns the node labeled by nodeKey the rank by updating graph and nodes data structures
    *
    * @param nodes - the Nodes
    * @param graph - the graph as list of nodes by level
-   * @param nodeName - the name of the node to set the rank of
+   * @param nodeKey - the name of the node to set the rank of
    * @param rank - the new rank for the node
    */
-  function assignRankToNode(nodeName: string, rank: number): void {
+  function assignRankToNode(nodeKey: string, rank: number): void {
     try {
-      graph[rank].push(nodeName);
+      graph[rank].push(nodeKey);
     } catch (err) {
-      graph[rank] = [nodeName];
+      graph[rank] = [nodeKey];
     } finally {
-      nodes[nodeName].rank = rank;
+      nodes[nodeKey].rank = rank;
     }
   }
 
@@ -357,10 +357,10 @@ function layoutCustom(pathway: Pathway): Layout {
     const nodes: Nodes = {};
 
     // Iniitalize each node with default values
-    let nodeName: string;
-    for (nodeName in pathway.nodes) {
-      nodes[nodeName] = {
-        label: nodeName,
+    let nodeKey: string;
+    for (nodeKey in pathway.nodes) {
+      nodes[nodeKey] = {
+        label: nodeKey,
         rank: NaN,
         horizontalPosition: NaN,
         children: [],
@@ -370,14 +370,14 @@ function layoutCustom(pathway: Pathway): Layout {
     }
 
     // Set the child and parent properties of each node
-    Object.keys(pathway.nodes).forEach(nodeName => {
-      const node: PathwayNode = pathway.nodes[nodeName];
+    Object.keys(pathway.nodes).forEach(nodeKey => {
+      const node: PathwayNode = pathway.nodes[nodeKey];
 
       node.transitions.forEach(transition => {
-        if (!nodes[nodeName].children.includes(transition.transition))
-          nodes[nodeName].children.push(transition.transition);
-        if (!nodes[transition.transition].parents.includes(nodeName))
-          nodes[transition.transition].parents.push(nodeName);
+        if (!nodes[nodeKey].children.includes(transition.transition))
+          nodes[nodeKey].children.push(transition.transition);
+        if (!nodes[transition.transition].parents.includes(nodeKey))
+          nodes[transition.transition].parents.push(nodeKey);
       });
     });
 


### PR DESCRIPTION
This is a refactoring PR, focused mainly on resolving conflicting variable/type names in the code.  The two main changes are:

State vs Node: All references to "State" have been replaced instead with "Node"

Action vs Guidance: Reference to "Guidance" have been replaced with "Action"

The changes have been broken up into different commits.  Though the code compiles/runs and the tests pass, there might be some errant name change that broke something.

Please let me know if you disagree with any of the name changes.

