### PR TITLE
Temporary fix for Chrome and FF bug with flex column wrapping

### DIFF
--- a/src/components/ReportModal/ReportSection/ReportSection.module.scss
+++ b/src/components/ReportModal/ReportSection/ReportSection.module.scss
@@ -2,9 +2,9 @@
 
 .fieldContainer {
   display: flex;
-  flex-direction: column;
+  writing-mode: vertical-lr;
   flex-wrap: wrap;
-  width: 90%;
+  max-width: 80em;
   justify-content: space-between;
   margin-left: 2em;
   > * {
@@ -19,6 +19,7 @@
   align-items: center;
   padding-bottom: 0.1em;
   line-height: 0.8;
+  writing-mode: initial;
   > b {
     margin-right: 0.5em;
   }


### PR DESCRIPTION
This PR is a temporary fix for the Chrome and Firefox bug we are seeing with flex column wrapping. This is a known [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=507397) that hasn't been fixed, but this is the workaround. This is needed for an upcoming demo.

Note: This fixes the issue on Chrome and Firefox, but seems to mess with the line-height in Firefox.

I recommend we create a new task to come up with a better fix for this, perhaps using tables instead of flexbox here.